### PR TITLE
Add registered & corporate addresses; add sales@vedpragya.com alongside support contacts

### DIFF
--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -136,6 +136,15 @@ export default function Footer() {
                 </svg>
                 support@vedpragya.com
               </a>
+              <a
+                href="mailto:sales@vedpragya.com"
+                className="flex items-center gap-2 text-sm text-white/40 hover:text-white/70 transition-colors"
+              >
+                <svg className="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                </svg>
+                sales@vedpragya.com
+              </a>
             </div>
           </div>
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -149,7 +149,7 @@ export default async function RootLayout({
           },
           {
             question: 'How do I get a project quote from Vedpragya?',
-            answer: 'Visit vedpragya.com/pages/contact or email support@vedpragya.com to share your project requirements. We provide free project consultations and detailed proposals within 24–48 hours.',
+            answer: 'Visit vedpragya.com/pages/contact or email support@vedpragya.com / sales@vedpragya.com to share your project requirements. We provide free project consultations and detailed proposals within 24–48 hours.',
           },
           {
             question: 'How many projects has Vedpragya delivered?',

--- a/app/pages/business-website/_components/final-cta-section.tsx
+++ b/app/pages/business-website/_components/final-cta-section.tsx
@@ -169,7 +169,7 @@ export function FinalCTASection() {
               WhatsApp
             </a>
             <a
-              href="mailto:support@vedpragya.com"
+              href="mailto:support@vedpragya.com,sales@vedpragya.com"
               className="flex items-center gap-1.5 sm:gap-2 hover:text-white transition-colors"
               onClick={() => console.log('[Business-Website] Final CTA - Email clicked')}
             >
@@ -194,4 +194,3 @@ export function FinalCTASection() {
     </section>
   );
 }
-

--- a/app/pages/business-website/_components/lead-form-section.tsx
+++ b/app/pages/business-website/_components/lead-form-section.tsx
@@ -663,7 +663,7 @@ export function LeadFormSection() {
                       We've received your request. Our team will contact you within 2 hours!
                     </p>
                     <p className="text-sm text-gray-600 dark:text-gray-400">
-                      Check your phone for a call from +91 9963730111 or email at support@vedpragya.com
+                      Check your phone for a call from +91 9963730111 or email at support@vedpragya.com / sales@vedpragya.com
                     </p>
                   </motion.div>
                 )}

--- a/app/pages/contact/page.tsx
+++ b/app/pages/contact/page.tsx
@@ -33,7 +33,8 @@ const serviceOptions = [
 ];
 
 const offices = [
-  { flag: "🇮🇳", country: "India", detail: "Haryana (HQ)", label: "Headquarters" },
+  { flag: "🇮🇳", country: "India", detail: "Registered Office: Bhiwani, Haryana", label: "Headquarters" },
+  { flag: "🇮🇳", country: "India", detail: "Corporate Office: Greater Noida (NX One, Tech Zone IV)", label: "Corporate Office" },
   { flag: "🇦🇪", country: "UAE", detail: "Dubai", label: "Middle East" },
   { flag: "🇺🇸", country: "USA", detail: "California", label: "North America" },
   { flag: "🇨🇦", country: "Canada", detail: "Toronto", label: "Canada" },
@@ -379,6 +380,17 @@ export default function ContactPage() {
                   </div>
                   <span className="font-medium text-sm">support@vedpragya.com</span>
                 </a>
+                <a
+                  href="mailto:sales@vedpragya.com"
+                  className="mt-2 flex items-center gap-3 text-[#0C1B33] hover:text-[#2563EB] transition-colors group"
+                >
+                  <div className="w-8 h-8 rounded-lg bg-gray-50 border border-gray-100 flex items-center justify-center shrink-0 group-hover:bg-[#2563EB]/8 transition-colors">
+                    <svg className="w-4 h-4 text-gray-400 group-hover:text-[#2563EB] transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                    </svg>
+                  </div>
+                  <span className="font-medium text-sm">sales@vedpragya.com</span>
+                </a>
               </div>
 
               {/* Office locations */}
@@ -424,7 +436,8 @@ export default function ContactPage() {
                   <strong className="text-[#0C1B33]">Vedpragya Bharat Private Limited</strong><br />
                   CIN: U47912HR2025PTC131357<br />
                   GST: 06AALCV0051A1ZV<br />
-                  Haryana, India
+                  Registered Address: C/o Aditi, Madhur Colony, Haluwas Opp Bansilal Park, Bhiwani, Bhiwani, Bhiwani - 127021, Haryana<br />
+                  Corporate Office: NX One, Tech Zone IV, Greater Noida
                 </p>
               </div>
             </div>

--- a/app/pages/legal/cancellations-refunds/page.tsx
+++ b/app/pages/legal/cancellations-refunds/page.tsx
@@ -224,7 +224,7 @@ export default function CancellationsRefundsPage() {
                 If you have concerns about our refund decision:
               </p>
               <ol className="list-decimal pl-6 text-gray-700 dark:text-gray-300 space-y-2">
-                <li>Contact our support team at <strong>support@vedpragya.com</strong> to discuss your concerns</li>
+                <li>Contact our support team at <strong>support@vedpragya.com / sales@vedpragya.com</strong> to discuss your concerns</li>
                 <li>We will review your case with senior management within 7 business days</li>
                 <li>If unresolved, we are open to mediation through an independent third party</li>
                 <li>Disputes will be governed by the laws of India (Jurisdiction: Haryana courts)</li>
@@ -274,7 +274,7 @@ export default function CancellationsRefundsPage() {
                   <strong>Refund Email:</strong> refunds@enterprisehero.com
                 </p>
                 <p className="text-gray-700 dark:text-gray-300 mb-2">
-                  <strong>Support Email:</strong> support@vedpragya.com
+                  <strong>Support Email:</strong> support@vedpragya.com / sales@vedpragya.com
                 </p>
                 <p className="text-gray-700 dark:text-gray-300">
                   <strong>Global Offices:</strong> India (HQ), Dubai, California, Toronto, Shenzhen

--- a/app/pages/legal/company-info/page.tsx
+++ b/app/pages/legal/company-info/page.tsx
@@ -56,6 +56,8 @@ export default function CompanyInfoPage() {
                     <p><strong>Company Type:</strong> Private Limited Company</p>
                     <p><strong>Incorporation Date:</strong> April 28, 2025</p>
                     <p><strong>Registration State:</strong> Haryana, India</p>
+                    <p><strong>Registered Address:</strong> C/o Aditi, Madhur Colony, Haluwas Opp Bansilal Park, Bhiwani, Bhiwani, Bhiwani - 127021, Haryana</p>
+                    <p><strong>Corporate Office:</strong> NX One, Tech Zone IV, Greater Noida</p>
                   </div>
                 </div>
                 <div>
@@ -115,8 +117,8 @@ export default function CompanyInfoPage() {
                     <h3 className="text-xl font-bold">India (Headquarters)</h3>
                   </div>
                   <div className="space-y-2 text-gray-700 dark:text-gray-300">
-                    <p><strong>Gurugram:</strong> Main corporate office</p>
-                    <p><strong>Noida:</strong> Development center</p>
+                    <p><strong>Bhiwani:</strong> Registered office</p>
+                    <p><strong>Greater Noida:</strong> Main corporate office (NX One, Tech Zone IV)</p>
                     <p><strong>Bangalore:</strong> Innovation hub</p>
                     <p className="text-sm text-blue-600 dark:text-blue-400 mt-3">
                       CIN: U47912HR2025PTC131357
@@ -258,7 +260,7 @@ export default function CompanyInfoPage() {
                 <div>
                   <h3 className="text-xl font-semibold mb-4">General Inquiries</h3>
                   <div className="space-y-2 text-gray-700 dark:text-gray-300">
-                    <p><strong>Email:</strong> info@enterprisehero.com</p>
+                    <p><strong>Email:</strong> support@vedpragya.com / sales@vedpragya.com</p>
                     <p><strong>Website:</strong> www.enterprisehero.com</p>
                     <p><strong>Business Hours:</strong> 24/7 Global Support</p>
                   </div>

--- a/app/pages/nse-mcx-live-market-data/_components/developer-resources-section.tsx
+++ b/app/pages/nse-mcx-live-market-data/_components/developer-resources-section.tsx
@@ -138,7 +138,7 @@ export function DeveloperResourcesSection() {
           <p className="text-white/80 mb-6">Our developer support team is here to help you 24/7</p>
           <div className="flex flex-wrap justify-center gap-4">
             <a
-              href="mailto:support@vedpragya.com"
+              href="mailto:support@vedpragya.com,sales@vedpragya.com"
               className="px-6 py-3 bg-gradient-to-r from-[#00FF88] to-[#00CC70] text-[#0B1E39] font-bold rounded-xl hover:scale-105 transition-all"
             >
               📧 Email Support

--- a/app/pages/nse-mcx-live-market-data/_components/faq-section.tsx
+++ b/app/pages/nse-mcx-live-market-data/_components/faq-section.tsx
@@ -141,7 +141,7 @@ export function FAQSection() {
             Still have questions? Our team is here to help!
           </p>
           <a
-            href="mailto:support@vedpragya.com"
+            href="mailto:support@vedpragya.com,sales@vedpragya.com"
             className="inline-flex items-center gap-2 px-8 py-4 bg-gradient-to-r from-[#00FF88] to-[#00CC70] text-[#0B1E39] font-black rounded-xl shadow-lg hover:shadow-2xl hover:shadow-[#00FF88]/50 transition-all duration-300 hover:scale-105"
           >
             📧 Contact Support

--- a/app/pages/website-development/_components/contact-section.tsx
+++ b/app/pages/website-development/_components/contact-section.tsx
@@ -198,7 +198,7 @@ export function ContactSection() {
                   </div>
                   <div>
                     <h4 className="font-medium">Email Us</h4>
-                    <p className="text-muted-foreground">support@vedpragya.com</p>
+                    <p className="text-muted-foreground">support@vedpragya.com / sales@vedpragya.com</p>
                   </div>
                 </div>
                 


### PR DESCRIPTION
### Motivation
- Make the public contact information accurate by adding the registered address in Bhiwani and the corporate office in Greater Noida, and provide a second contact channel (`sales@vedpragya.com`) alongside the existing support email for inbound enquiries.

### Description
- Added Registered Address `C/o Aditi, Madhur Colony, Haluwas Opp Bansilal Park, Bhiwani, Bhiwani, Bhiwani - 127021, Haryana` and Corporate Office `NX One, Tech Zone IV, Greater Noida` to the Contact page (`app/pages/contact/page.tsx`) and Company Info legal page (`app/pages/legal/company-info/page.tsx`).
- Updated the Contact page `offices` list to include Bhiwani (registered office) and Greater Noida (corporate office) and added a visible `sales@vedpragya.com` mailto link next to support in the direct contact card.
- Added `sales@vedpragya.com` to the site footer (`app/components/Footer.tsx`) as a separate mailto link.
- Propagated the sales address/email alongside support in multiple user touchpoints and CTAs including `app/layout.tsx`, `app/pages/business-website/_components/lead-form-section.tsx`, `app/pages/business-website/_components/final-cta-section.tsx`, `app/pages/nse-mcx-live-market-data/_components/faq-section.tsx`, `app/pages/nse-mcx-live-market-data/_components/developer-resources-section.tsx`, and `app/pages/website-development/_components/contact-section.tsx`, and the cancellations & refunds page (`app/pages/legal/cancellations-refunds/page.tsx`).
- Normalized multi-recipient mailto links where needed to use comma-separated recipients (`mailto:support@vedpragya.com,sales@vedpragya.com`) so both addresses are included when a user clicks an Email CTA.
- Committed changes (10 files changed).

### Testing
- Ran repository searches to verify occurrences of `support@vedpragya.com` were updated; confirmations found in the modified files (success).
- Attempted automated lint via `npm run -s lint`, but it failed due to missing `next` binary in the execution environment (`sh: 1: next: not found`).
- Changes were staged and committed successfully to the current branch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e03c4fed2c8322aff3fd6a1f4fa649)