### PR TITLE
Fix Client Dashboard button visibility in header

### DIFF
--- a/app/components/EnhancedHeader.tsx
+++ b/app/components/EnhancedHeader.tsx
@@ -188,6 +188,15 @@ export default function EnhancedHeader() {
                   </nav>
 
                   <div className="flex items-center gap-1.5">
+                    <a
+                      href="https://client.vedpragya.com"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="hidden lg:inline-flex items-center gap-1.5 px-3.5 py-2 text-sm font-medium text-gray-700 dark:text-gray-200 hover:text-[#0C1B33] dark:hover:text-white hover:bg-gray-100 dark:hover:bg-[#151C2B] rounded-lg transition-all min-h-[40px]"
+                      style={{ fontFamily: "var(--font-sora), sans-serif" }}
+                    >
+                      Client Dashboard
+                    </a>
                     <Link
                       href="/pages/contact"
                       className="hidden lg:inline-flex items-center gap-1.5 px-4 py-2 bg-[#2563EB] hover:bg-[#1D4ED8] text-white font-semibold text-sm rounded-lg transition-all shadow-[0_2px_8px_rgba(37,99,235,0.30)] hover:shadow-[0_4px_16px_rgba(37,99,235,0.40)] min-h-[40px]"
@@ -264,6 +273,15 @@ export default function EnhancedHeader() {
                   </nav>
 
                   <div className="flex items-center gap-1.5">
+                    <a
+                      href="https://client.vedpragya.com"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="hidden lg:inline-flex items-center gap-1.5 px-3.5 py-2 text-sm font-medium text-gray-700 dark:text-gray-200 hover:text-[#0C1B33] dark:hover:text-white hover:bg-gray-100 dark:hover:bg-[#151C2B] rounded-lg transition-all min-h-[44px]"
+                      style={{ fontFamily: "var(--font-sora), sans-serif" }}
+                    >
+                      Client Dashboard
+                    </a>
                     <Link
                       href="/pages/contact"
                       className="hidden lg:inline-flex items-center gap-1.5 px-4 py-2 bg-[#2563EB] hover:bg-[#1D4ED8] text-white font-semibold text-sm rounded-lg transition-all shadow-[0_2px_8px_rgba(37,99,235,0.30)] hover:shadow-[0_4px_16px_rgba(37,99,235,0.40)] min-h-[44px]"


### PR DESCRIPTION
### Motivation
- The Client Dashboard entry was not clearly available from the main header, so users could not easily reach `https://client.vedpragya.com` from desktop navigation.

### Description
- Added a dedicated external link button `Client Dashboard` to the desktop header action area in `app/components/EnhancedHeader.tsx` for both header states (top/default and scrolled/floating). 
- The new element is an `<a href="https://client.vedpragya.com" target="_blank" rel="noopener noreferrer">` to open the dashboard in a new tab securely.
- The link uses `hidden lg:inline-flex` classes so it is visible on large screens and matches existing header styles and spacing.
- Changes were committed to the repository (modified file: `app/components/EnhancedHeader.tsx`).

### Testing
- Attempted to run lint on the edited file with `npm run lint -- --file app/components/EnhancedHeader.tsx`, but the command could not complete because the `next` binary is not available in the current environment (`sh: 1: next: not found`).
- No other automated tests were executed in this environment due to missing dependencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e056db7a1083228f3d4a9bf13af1e9)