### PR TITLE
Remove incorporation date from site content and structured data

### DIFF
--- a/app/data/companyProfile.ts
+++ b/app/data/companyProfile.ts
@@ -4,7 +4,7 @@
  *
  * WHY THIS EXISTS:
  * - Avoids "fake" / placeholder data (e.g. random US address, "#" social links)
- * - Keeps legal identifiers consistent everywhere (CIN/GST/incorporation date)
+ * - Keeps legal identifiers consistent everywhere (CIN/GST/registration state)
  * - Makes it easy to update without hunting through many pages/components
  *
  * GUIDELINES (Authenticity-first):
@@ -29,7 +29,6 @@ export interface CompanyProfile {
   legal: {
     cin?: string;
     gst?: string;
-    incorporationDateISO?: string; // e.g. "2025-04-28"
     registrationState?: string; // e.g. "Haryana, India"
   };
   founder?: {
@@ -52,8 +51,6 @@ export const companyProfile: CompanyProfile = {
   legal: {
     cin: "U47912HR2025PTC131357",
     gst: "06AALCV0051A1ZV",
-    // Source: /pages/legal/company-info
-    incorporationDateISO: "2025-04-28",
     registrationState: "Haryana, India",
   },
   founder: {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -166,7 +166,6 @@ export default async function RootLayout({
           url={companyProfile.websiteUrl}
           logo={`${SEO_SITE_URL}/logo.png`}
           description="Enterprise-grade software development, AI systems, ERP, e-commerce, and digital marketing services."
-          foundingDate={companyProfile.legal.incorporationDateISO}
           address={{
             addressLocality: 'Haryana',
             addressRegion: 'Haryana',

--- a/app/pages/about/page.tsx
+++ b/app/pages/about/page.tsx
@@ -4,7 +4,7 @@ import { Spotlight } from "@/app/components/ui/spotlight";
 import { MovingBorder } from "@/app/components/ui/moving-border";
 
 const milestones = [
-  { year: "2025", event: "Founded", desc: "Vedpragya Bharat Private Limited incorporated in Haryana, India by Aman Kumar Sharma." },
+  { year: "2025", event: "Founded", desc: "Vedpragya Bharat Private Limited was founded in Haryana, India by Aman Kumar Sharma." },
   { year: "2025", event: "First Enterprise Client", desc: "Delivered BharatERP to first enterprise client in the manufacturing sector." },
   { year: "2025", event: "100 Projects", desc: "Crossed 100 delivered projects across web, mobile, AI, and ERP domains." },
   { year: "2026", event: "Global Expansion", desc: "Opened offices in Dubai UAE and expanded client base to North America." },

--- a/app/pages/legal/company-info/page.tsx
+++ b/app/pages/legal/company-info/page.tsx
@@ -54,7 +54,6 @@ export default function CompanyInfoPage() {
                     <p><strong>Legal Name:</strong> Vedpragya Bharat Private Limited</p>
                     <p><strong>Brand Name:</strong> Enterprise Hero</p>
                     <p><strong>Company Type:</strong> Private Limited Company</p>
-                    <p><strong>Incorporation Date:</strong> April 28, 2025</p>
                     <p><strong>Registration State:</strong> Haryana, India</p>
                     <p><strong>Registered Address:</strong> C/o Aditi, Madhur Colony, Haluwas Opp Bansilal Park, Bhiwani, Bhiwani, Bhiwani - 127021, Haryana</p>
                     <p><strong>Corporate Office:</strong> NX One, Tech Zone IV, Greater Noida</p>

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -141,12 +141,12 @@ const ROUTE_LAST_MODIFIED_MAP: Record<string, Date> = {
   '/pages/web-development-noida': new Date('2026-04-14T00:00:00.000Z'),
   '/pages/nodejs-development': new Date('2026-04-14T00:00:00.000Z'),
 
-  // Legal pages — stable; set to incorporation date to avoid false freshness signals
-  '/pages/legal/privacy-policy': new Date('2025-04-28T00:00:00.000Z'),
-  '/pages/legal/terms-of-service': new Date('2025-04-28T00:00:00.000Z'),
-  '/pages/legal/cancellations-refunds': new Date('2025-04-28T00:00:00.000Z'),
-  '/pages/legal/shipping-policy': new Date('2025-04-28T00:00:00.000Z'),
-  '/pages/legal/company-info': new Date('2025-04-28T00:00:00.000Z'),
+  // Legal pages — stable; use a fixed baseline date to avoid false freshness signals
+  '/pages/legal/privacy-policy': new Date('2025-01-01T00:00:00.000Z'),
+  '/pages/legal/terms-of-service': new Date('2025-01-01T00:00:00.000Z'),
+  '/pages/legal/cancellations-refunds': new Date('2025-01-01T00:00:00.000Z'),
+  '/pages/legal/shipping-policy': new Date('2025-01-01T00:00:00.000Z'),
+  '/pages/legal/company-info': new Date('2025-01-01T00:00:00.000Z'),
 };
 
 /**


### PR DESCRIPTION
### Motivation
- Remove any visible or structured reference to the company's date of incorporation so the site never displays the April 28 incorporation date.
- Ensure the centralized company profile and JSON-LD output no longer expose a founding/incorporation date.

### Description
- Removed the `incorporationDateISO` field and value from `app/data/companyProfile.ts` and updated the file comment to stop referencing the incorporation date.
- Deleted the visible "Incorporation Date" row from `app/pages/legal/company-info/page.tsx` so the date no longer appears on the legal info page.
- Stopped passing `foundingDate` to `ProfessionalServiceStructuredData` in `app/layout.tsx` to prevent the date being emitted in JSON-LD.
- Updated the About timeline wording in `app/pages/about/page.tsx` to remove the "incorporated" phrasing and replaced legal sitemap timestamps in `app/sitemap.ts` that referenced `2025-04-28` with a neutral baseline date (`2025-01-01`) and updated the explanatory comment.

### Testing
- Ran codebase searches with `rg` to confirm `2025-04-28`, `April 28, 2025`, `Incorporation Date`, and `incorporationDateISO` no longer appear in the `app` source tree, which succeeded.
- Attempted to run the linter (`npm run -s lint`) but it could not complete in this environment because `next` is not available in `PATH` and the lint step failed with that environment error.
- Sanity-checked the edited files (`app/data/companyProfile.ts`, `app/pages/legal/company-info/page.tsx`, `app/layout.tsx`, `app/pages/about/page.tsx`, `app/sitemap.ts`) to verify the intended removals and text updates were applied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e78979f7408322acfc00006038d84d)