### PR TITLE
Add SaaS website design landing page

### DIFF
--- a/app/lib/seo/routes.ts
+++ b/app/lib/seo/routes.ts
@@ -34,6 +34,7 @@ const CORE_STATIC_ROUTES = [
   '/pages/next-js-development',
   '/pages/reactjs-development',
   '/pages/nodejs-development',
+  '/pages/saas-website-design',
 
   // AI & automation services
   '/pages/ai-chatbot-development',
@@ -93,6 +94,7 @@ const ALL_STATIC_PAGE_ROUTES = [
   '/pages/portfolio',
   '/pages/reactjs-development',
   '/pages/resources',
+  '/pages/saas-website-design',
   '/pages/seo-audit',
   '/pages/services',
   '/pages/shopify-headless-migration',

--- a/app/pages/saas-website-design/_components/faq-section.tsx
+++ b/app/pages/saas-website-design/_components/faq-section.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import React, { useRef, useState } from 'react';
+import { motion, useInView, AnimatePresence } from 'framer-motion';
+import { ChevronDown } from 'lucide-react';
+
+const FAQS = [
+  {
+    q: 'What makes a great SaaS marketing website?',
+    a: 'A crystal-clear value proposition above the fold, social proof (logos, testimonials, case studies), feature walkthroughs that address objections, and a frictionless CTA flow. It loads in under 2 seconds and scores 90+ on Core Web Vitals. We build all of this with Next.js and Tailwind.',
+  },
+  {
+    q: 'How much does SaaS website design cost in India?',
+    a: 'A focused SaaS marketing site starts at ₹80,000 for a 5-page package. A full design system with landing pages, blog, and CMS integration starts at ₹2,50,000. Enterprise sites with custom animations are quoted on request.',
+  },
+  {
+    q: 'How long does it take to build a SaaS website?',
+    a: 'A focused homepage with core marketing pages takes 3–4 weeks. A full marketing site with blog, docs, pricing, and CMS integration takes 6–10 weeks. We work in two-week sprints with design-then-code handoff.',
+  },
+  {
+    q: 'Do you design or just develop?',
+    a: 'Both. We handle strategy, UX wireframes, visual design, and development end-to-end. If you have Figma designs, we build pixel-perfect from them. We align to your brand or create a new design system from scratch.',
+  },
+  {
+    q: 'Can you integrate with HubSpot, Intercom, or our app?',
+    a: 'Yes. We integrate GA4, Mixpanel, Segment, HubSpot, Intercom, Customer.io, and auth redirects to your product. If your app has an API, we can connect to it.',
+  },
+  {
+    q: 'Will the site rank on Google?',
+    a: 'SEO is built in, not bolted on. Every page ships with canonical tags, JSON-LD structured data, semantic HTML, next/image optimisation, sitemap.xml, and robots.txt. We also plan your content architecture for long-term organic growth.',
+  },
+];
+
+export function FAQSection() {
+  const ref = useRef<HTMLDivElement>(null);
+  const inView = useInView(ref, { once: true, amount: 0.15 });
+  const [open, setOpen] = useState<number | null>(null);
+
+  return (
+    <section ref={ref} className="py-20 md:py-28 bg-white dark:bg-gray-950">
+      <div className="container mx-auto px-4 max-w-3xl">
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={inView ? { opacity: 1, y: 0 } : {}}
+          transition={{ duration: 0.5 }}
+        >
+          <p className="text-xs uppercase tracking-widest text-indigo-600 dark:text-indigo-400 font-bold mb-3 text-center">
+            FAQ
+          </p>
+          <h2 className="text-3xl sm:text-4xl font-black tracking-tight text-center mb-12 text-gray-900 dark:text-white">
+            Common questions
+          </h2>
+        </motion.div>
+
+        <div className="space-y-3">
+          {FAQS.map((faq, i) => (
+            <motion.div
+              key={i}
+              initial={{ opacity: 0, y: 12 }}
+              animate={inView ? { opacity: 1, y: 0 } : {}}
+              transition={{ duration: 0.4, delay: i * 0.05 }}
+              className="border border-gray-200 dark:border-gray-800 rounded-xl overflow-hidden"
+            >
+              <button
+                onClick={() => setOpen(open === i ? null : i)}
+                className="w-full flex items-center justify-between p-5 text-left bg-white dark:bg-gray-900 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+                aria-expanded={open === i}
+              >
+                <span className="font-bold text-gray-900 dark:text-white text-sm pr-4">
+                  {faq.q}
+                </span>
+                <ChevronDown
+                  className={`h-4 w-4 text-gray-400 flex-shrink-0 transition-transform duration-200 ${open === i ? 'rotate-180' : ''}`}
+                />
+              </button>
+              <AnimatePresence initial={false}>
+                {open === i && (
+                  <motion.div
+                    key="content"
+                    initial={{ height: 0, opacity: 0 }}
+                    animate={{ height: 'auto', opacity: 1 }}
+                    exit={{ height: 0, opacity: 0 }}
+                    transition={{ duration: 0.2, ease: 'easeInOut' }}
+                  >
+                    <p className="px-5 pb-5 text-sm text-gray-500 dark:text-gray-400 leading-relaxed bg-white dark:bg-gray-900">
+                      {faq.a}
+                    </p>
+                  </motion.div>
+                )}
+              </AnimatePresence>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/app/pages/saas-website-design/_components/final-cta-section.tsx
+++ b/app/pages/saas-website-design/_components/final-cta-section.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import React, { useRef } from 'react';
+import { motion, useInView } from 'framer-motion';
+import { Button } from '@/app/components/ui/button';
+import { ArrowRight } from 'lucide-react';
+
+export function FinalCtaSection() {
+  const ref = useRef<HTMLDivElement>(null);
+  const inView = useInView(ref, { once: true, amount: 0.3 });
+
+  return (
+    <section ref={ref} className="py-20 md:py-28 bg-indigo-600 dark:bg-indigo-700">
+      <div className="container mx-auto px-4 max-w-4xl text-center">
+        <motion.div
+          initial={{ opacity: 0, y: 24 }}
+          animate={inView ? { opacity: 1, y: 0 } : {}}
+          transition={{ duration: 0.55 }}
+        >
+          <h2 className="text-3xl sm:text-4xl md:text-5xl font-black tracking-tight text-white mb-5 leading-tight">
+            Your SaaS deserves a website<br />that works as hard as you do.
+          </h2>
+          <p className="text-indigo-200 text-base sm:text-lg mb-10 max-w-xl mx-auto">
+            Join 40+ SaaS teams who ship with Vedpragya. Free consultation, no commitment.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-3 justify-center">
+            <Button
+              asChild
+              size="lg"
+              className="bg-white text-indigo-700 hover:bg-indigo-50 font-bold px-8 py-6 text-base rounded-xl shadow-lg"
+            >
+              <a href="#lead-form">
+                Start your project <ArrowRight className="ml-2 h-4 w-4" />
+              </a>
+            </Button>
+            <Button
+              asChild
+              variant="outline"
+              size="lg"
+              className="border-white/40 text-white hover:bg-white/10 font-semibold px-8 py-6 text-base rounded-xl"
+            >
+              <a href="/pages/portfolio">View portfolio</a>
+            </Button>
+          </div>
+        </motion.div>
+      </div>
+    </section>
+  );
+}

--- a/app/pages/saas-website-design/_components/hero-section.tsx
+++ b/app/pages/saas-website-design/_components/hero-section.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import React, { useRef } from 'react';
+import { motion, useInView } from 'framer-motion';
+import { Button } from '@/app/components/ui/button';
+import { ArrowRight, Zap, Globe, Star } from 'lucide-react';
+
+const fadeUp = {
+  hidden: { opacity: 0, y: 24 },
+  show: { opacity: 1, y: 0, transition: { duration: 0.55, ease: 'easeOut' } },
+};
+
+export function HeroSection() {
+  const ref = useRef<HTMLDivElement>(null);
+  const inView = useInView(ref, { once: true, amount: 0.25 });
+
+  return (
+    <section
+      ref={ref}
+      id="home"
+      className="relative min-h-screen flex items-center bg-white dark:bg-gray-950 overflow-hidden"
+      role="region"
+      aria-labelledby="hero-heading"
+    >
+      {/* Subtle grid background */}
+      <div
+        className="pointer-events-none absolute inset-0 opacity-[0.03] dark:opacity-[0.07]"
+        style={{
+          backgroundImage:
+            'linear-gradient(to right, #6366f1 1px, transparent 1px), linear-gradient(to bottom, #6366f1 1px, transparent 1px)',
+          backgroundSize: '48px 48px',
+        }}
+      />
+
+      {/* Radial glow */}
+      <div className="pointer-events-none absolute -top-40 left-1/2 -translate-x-1/2 w-[720px] h-[480px] bg-indigo-500/10 dark:bg-indigo-500/20 rounded-full blur-3xl" />
+
+      <div className="container mx-auto px-4 pt-28 pb-20 md:pt-36 md:pb-28 relative z-10 max-w-6xl">
+        <motion.div
+          initial="hidden"
+          animate={inView ? 'show' : 'hidden'}
+          variants={{ show: { transition: { staggerChildren: 0.11 } } }}
+          className="text-center"
+        >
+          {/* Trust chips */}
+          <motion.div variants={fadeUp} className="flex flex-wrap justify-center gap-2 mb-8">
+            {[
+              { icon: <Zap className="h-3 w-3" />, text: '40+ SaaS sites shipped' },
+              { icon: <Globe className="h-3 w-3" />, text: 'Clients in 8 countries' },
+              { icon: <Star className="h-3 w-3" />, text: '98 PageSpeed score' },
+            ].map((chip, i) => (
+              <span
+                key={i}
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full border border-gray-200 dark:border-gray-700 bg-white/90 dark:bg-gray-800/90 text-xs font-semibold text-gray-700 dark:text-gray-200 shadow-sm"
+              >
+                {chip.icon}
+                {chip.text}
+              </span>
+            ))}
+          </motion.div>
+
+          {/* H1 */}
+          <motion.h1
+            id="hero-heading"
+            variants={fadeUp}
+            className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-black tracking-tight leading-[1.08] mb-6 text-gray-900 dark:text-white"
+          >
+            SaaS websites that{' '}
+            <span className="relative inline-block">
+              <span className="relative z-10 text-indigo-600 dark:text-indigo-400">
+                convert visitors
+              </span>
+              <span className="absolute bottom-1 left-0 w-full h-3 bg-indigo-100 dark:bg-indigo-900/40 -z-0 rounded" />
+            </span>
+            <br />
+            into paying users
+          </motion.h1>
+
+          {/* Sub-headline */}
+          <motion.p
+            variants={fadeUp}
+            className="text-lg sm:text-xl text-gray-600 dark:text-gray-400 max-w-2xl mx-auto mb-10 leading-relaxed"
+          >
+            We design and build high-performance marketing sites, landing pages, and pricing pages
+            for SaaS companies — with{' '}
+            <strong className="text-gray-900 dark:text-white">Next.js, Tailwind, and Framer Motion</strong>.
+            Opinionated design. Measurable results.
+          </motion.p>
+
+          {/* CTAs */}
+          <motion.div
+            variants={fadeUp}
+            className="flex flex-col sm:flex-row gap-3 justify-center"
+          >
+            <Button
+              asChild
+              size="lg"
+              className="bg-indigo-600 hover:bg-indigo-700 text-white font-bold px-8 py-6 text-base rounded-xl shadow-lg shadow-indigo-600/25"
+            >
+              <a href="#lead-form">
+                Start your SaaS site <ArrowRight className="ml-2 h-4 w-4" />
+              </a>
+            </Button>
+            <Button
+              asChild
+              variant="outline"
+              size="lg"
+              className="font-semibold px-8 py-6 text-base rounded-xl border-gray-300 dark:border-gray-600"
+            >
+              <a href="/pages/portfolio">See our work</a>
+            </Button>
+          </motion.div>
+
+          {/* Social proof logos row */}
+          <motion.p
+            variants={fadeUp}
+            className="mt-12 text-xs text-gray-400 dark:text-gray-600 uppercase tracking-widest font-semibold"
+          >
+            Trusted by SaaS teams across India, US, UK &amp; Australia
+          </motion.p>
+        </motion.div>
+      </div>
+    </section>
+  );
+}

--- a/app/pages/saas-website-design/_components/lead-form-section.tsx
+++ b/app/pages/saas-website-design/_components/lead-form-section.tsx
@@ -1,0 +1,322 @@
+'use client';
+
+import React, { useState, useRef } from 'react';
+import { motion, useInView } from 'framer-motion';
+import { Button } from '@/app/components/ui/button';
+import { Input } from '@/app/components/ui/input';
+import { Textarea } from '@/app/components/ui/textarea';
+import { Label } from '@/app/components/ui/label';
+import { Phone, MessageCircle, ArrowRight, CheckCircle } from 'lucide-react';
+import { fireConversion } from '@/utils/conversions';
+
+interface FormData {
+  name: string;
+  phone: string;
+  email: string;
+  company: string;
+  projectType: string;
+  message: string;
+}
+
+const PROJECT_TYPES = [
+  'New SaaS marketing site',
+  'Pricing / landing page',
+  'Redesign existing site',
+  'Docs / help centre',
+  'Launch / waitlist page',
+  'Other',
+];
+
+export function LeadFormSection() {
+  const sectionRef = useRef<HTMLDivElement>(null);
+  const inView = useInView(sectionRef, { once: true, amount: 0.1 });
+
+  const [formData, setFormData] = useState<FormData>({
+    name: '',
+    phone: '',
+    email: '',
+    company: '',
+    projectType: '',
+    message: '',
+  });
+  const [submitted, setSubmitted] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>
+  ) => {
+    setFormData((prev) => ({ ...prev, [e.target.name]: e.target.value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      const res = await fetch('/api/lead', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: formData.name,
+          email: formData.email,
+          phone: formData.phone,
+          message: formData.message,
+          source: 'saas-website-design',
+          leadSource: 'Website - SaaS Design Landing',
+          raw: {
+            company: formData.company,
+            projectType: formData.projectType,
+            path: typeof window !== 'undefined' ? window.location.pathname : undefined,
+          },
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.error || 'Lead API failed');
+      setSubmitted(true);
+      void fireConversion('saas_website_design_lead_submit');
+    } catch {
+      alert('Something went wrong. Please try again or contact us directly.');
+    } finally {
+      setLoading(false);
+    }
+
+    setTimeout(() => {
+      setSubmitted(false);
+      setFormData({ name: '', phone: '', email: '', company: '', projectType: '', message: '' });
+    }, 5000);
+  };
+
+  return (
+    <section
+      ref={sectionRef}
+      id="lead-form"
+      className="py-20 md:py-28 bg-gradient-to-br from-indigo-50 via-white to-violet-50 dark:from-gray-950 dark:via-gray-900 dark:to-indigo-950"
+      role="region"
+      aria-labelledby="form-heading"
+    >
+      <div className="container mx-auto px-4 max-w-6xl">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-10 lg:gap-16 items-start">
+
+          {/* Left: value prop */}
+          <motion.div
+            initial={{ opacity: 0, x: -24 }}
+            animate={inView ? { opacity: 1, x: 0 } : {}}
+            transition={{ duration: 0.55 }}
+            className="lg:sticky lg:top-24"
+          >
+            <span className="inline-block px-4 py-1.5 rounded-full bg-indigo-100 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-300 text-xs font-bold uppercase tracking-widest mb-5">
+              Free Consultation
+            </span>
+            <h2
+              id="form-heading"
+              className="text-3xl sm:text-4xl md:text-5xl font-black tracking-tight text-gray-900 dark:text-white mb-4 leading-tight"
+            >
+              Ready to build a SaaS site that{' '}
+              <span className="text-indigo-600 dark:text-indigo-400">actually converts?</span>
+            </h2>
+            <p className="text-gray-500 dark:text-gray-400 mb-8 text-base leading-relaxed">
+              Tell us about your product. We'll respond within 2 hours with a scope, timeline, and
+              ballpark — no commitment required.
+            </p>
+
+            <ul className="space-y-3 mb-8">
+              {[
+                '2-hour response guarantee',
+                'Free scope & timeline estimate',
+                'Design consultation included',
+                '100% confidential',
+              ].map((item, i) => (
+                <li key={i} className="flex items-center gap-2.5 text-sm font-semibold text-gray-700 dark:text-gray-300">
+                  <CheckCircle className="h-4 w-4 text-indigo-500 flex-shrink-0" />
+                  {item}
+                </li>
+              ))}
+            </ul>
+
+            <div className="bg-white dark:bg-gray-900 rounded-2xl p-5 border border-gray-200 dark:border-gray-700 shadow-sm space-y-3">
+              <p className="text-xs font-bold uppercase tracking-widest text-gray-400 mb-1">Or contact directly</p>
+              <a
+                href="tel:+919963730111"
+                onClick={() => void fireConversion('saas_design_call_click')}
+                className="flex items-center gap-3 p-3 rounded-xl bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 hover:border-green-400 transition-colors group"
+              >
+                <div className="w-10 h-10 rounded-full bg-green-600 flex items-center justify-center flex-shrink-0">
+                  <Phone className="h-5 w-5 text-white" />
+                </div>
+                <div>
+                  <p className="text-[10px] uppercase tracking-widest text-gray-500 font-bold">Call now</p>
+                  <p className="font-bold text-sm text-gray-900 dark:text-white group-hover:text-green-600 dark:group-hover:text-green-400">
+                    +91 9963730111
+                  </p>
+                </div>
+              </a>
+              <a
+                href="https://wa.me/919963730111"
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() => void fireConversion('saas_design_whatsapp_click')}
+                className="flex items-center gap-3 p-3 rounded-xl bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 hover:border-green-400 transition-colors group"
+              >
+                <div className="w-10 h-10 rounded-full bg-green-600 flex items-center justify-center flex-shrink-0">
+                  <MessageCircle className="h-5 w-5 text-white" />
+                </div>
+                <div>
+                  <p className="text-[10px] uppercase tracking-widest text-gray-500 font-bold">WhatsApp</p>
+                  <p className="font-bold text-sm text-gray-900 dark:text-white group-hover:text-green-600 dark:group-hover:text-green-400">
+                    Chat now
+                  </p>
+                </div>
+              </a>
+            </div>
+          </motion.div>
+
+          {/* Right: form */}
+          <motion.div
+            initial={{ opacity: 0, x: 24 }}
+            animate={inView ? { opacity: 1, x: 0 } : {}}
+            transition={{ duration: 0.55, delay: 0.15 }}
+          >
+            <div className="bg-white dark:bg-gray-900 rounded-3xl p-7 sm:p-8 shadow-xl border-2 border-indigo-100 dark:border-indigo-900">
+              {!submitted ? (
+                <form onSubmit={handleSubmit} className="space-y-5">
+                  <div>
+                    <Label htmlFor="name" className="font-bold text-sm mb-1.5 block">
+                      Name <span className="text-red-500">*</span>
+                    </Label>
+                    <Input
+                      id="name"
+                      name="name"
+                      required
+                      value={formData.name}
+                      onChange={handleChange}
+                      placeholder="Your full name"
+                      className="h-12"
+                    />
+                  </div>
+
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                    <div>
+                      <Label htmlFor="phone" className="font-bold text-sm mb-1.5 block">
+                        Phone <span className="text-red-500">*</span>
+                      </Label>
+                      <Input
+                        id="phone"
+                        name="phone"
+                        type="tel"
+                        required
+                        value={formData.phone}
+                        onChange={handleChange}
+                        placeholder="+91 9963730111"
+                        className="h-12"
+                      />
+                    </div>
+                    <div>
+                      <Label htmlFor="email" className="font-bold text-sm mb-1.5 block">
+                        Email
+                      </Label>
+                      <Input
+                        id="email"
+                        name="email"
+                        type="email"
+                        value={formData.email}
+                        onChange={handleChange}
+                        placeholder="you@company.com"
+                        className="h-12"
+                      />
+                    </div>
+                  </div>
+
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                    <div>
+                      <Label htmlFor="company" className="font-bold text-sm mb-1.5 block">
+                        Company / SaaS name
+                      </Label>
+                      <Input
+                        id="company"
+                        name="company"
+                        value={formData.company}
+                        onChange={handleChange}
+                        placeholder="Acme Inc."
+                        className="h-12"
+                      />
+                    </div>
+                    <div>
+                      <Label htmlFor="projectType" className="font-bold text-sm mb-1.5 block">
+                        Project type
+                      </Label>
+                      <select
+                        id="projectType"
+                        name="projectType"
+                        value={formData.projectType}
+                        onChange={handleChange}
+                        className="w-full h-12 rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none"
+                      >
+                        <option value="">Select type</option>
+                        {PROJECT_TYPES.map((t) => (
+                          <option key={t} value={t}>
+                            {t}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  </div>
+
+                  <div>
+                    <Label htmlFor="message" className="font-bold text-sm mb-1.5 block">
+                      Tell us about your project
+                    </Label>
+                    <Textarea
+                      id="message"
+                      name="message"
+                      value={formData.message}
+                      onChange={handleChange}
+                      placeholder="What does your SaaS do? What's missing from the current site?"
+                      rows={4}
+                    />
+                  </div>
+
+                  <Button
+                    type="submit"
+                    size="lg"
+                    disabled={loading}
+                    className="w-full h-14 text-base font-bold bg-indigo-600 hover:bg-indigo-700 rounded-xl shadow-lg shadow-indigo-600/20"
+                  >
+                    {loading ? (
+                      <span className="flex items-center gap-2">
+                        <span className="animate-spin h-4 w-4 border-2 border-white border-t-transparent rounded-full" />
+                        Sending…
+                      </span>
+                    ) : (
+                      <>
+                        Get a free consultation <ArrowRight className="ml-2 h-4 w-4" />
+                      </>
+                    )}
+                  </Button>
+
+                  <p className="text-center text-xs text-gray-400">
+                    No spam · 2-hour response · 100% confidential
+                  </p>
+                </form>
+              ) : (
+                <motion.div
+                  initial={{ scale: 0.9, opacity: 0 }}
+                  animate={{ scale: 1, opacity: 1 }}
+                  className="text-center py-12"
+                >
+                  <div className="w-16 h-16 rounded-full bg-green-100 dark:bg-green-900/30 mx-auto mb-5 flex items-center justify-center">
+                    <CheckCircle className="h-9 w-9 text-green-600 dark:text-green-400" />
+                  </div>
+                  <h3 className="text-2xl font-black text-gray-900 dark:text-white mb-2">
+                    Request received!
+                  </h3>
+                  <p className="text-gray-500 dark:text-gray-400 text-sm">
+                    We'll call you within 2 hours. Talk soon.
+                  </p>
+                </motion.div>
+              )}
+            </div>
+          </motion.div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/app/pages/saas-website-design/_components/tech-stack-section.tsx
+++ b/app/pages/saas-website-design/_components/tech-stack-section.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import React, { useRef } from 'react';
+import { motion, useInView } from 'framer-motion';
+
+const STACK = [
+  { name: 'Next.js 15', tag: 'Framework', color: 'bg-black text-white dark:bg-white dark:text-black' },
+  { name: 'React 19', tag: 'UI', color: 'bg-sky-500 text-white' },
+  { name: 'Tailwind v4', tag: 'Styling', color: 'bg-teal-500 text-white' },
+  { name: 'Framer Motion', tag: 'Animation', color: 'bg-violet-500 text-white' },
+  { name: 'TypeScript', tag: 'Language', color: 'bg-blue-600 text-white' },
+  { name: 'Prisma', tag: 'Database', color: 'bg-indigo-600 text-white' },
+  { name: 'Contentlayer / MDX', tag: 'CMS', color: 'bg-orange-500 text-white' },
+  { name: 'Vercel / AWS', tag: 'Hosting', color: 'bg-gray-800 text-white dark:bg-gray-200 dark:text-gray-800' },
+];
+
+const fadeUp = {
+  hidden: { opacity: 0, y: 16 },
+  show: { opacity: 1, y: 0, transition: { duration: 0.45, ease: 'easeOut' } },
+};
+
+export function TechStackSection() {
+  const ref = useRef<HTMLDivElement>(null);
+  const inView = useInView(ref, { once: true, amount: 0.2 });
+
+  return (
+    <section ref={ref} className="py-20 md:py-28 bg-gray-50 dark:bg-gray-900">
+      <div className="container mx-auto px-4 max-w-6xl">
+        <motion.div
+          initial="hidden"
+          animate={inView ? 'show' : 'hidden'}
+          variants={{ show: { transition: { staggerChildren: 0.08 } } }}
+        >
+          <motion.p
+            variants={fadeUp}
+            className="text-xs uppercase tracking-widest text-indigo-600 dark:text-indigo-400 font-bold mb-3 text-center"
+          >
+            Tech stack
+          </motion.p>
+          <motion.h2
+            variants={fadeUp}
+            className="text-3xl sm:text-4xl font-black tracking-tight text-center mb-4 text-gray-900 dark:text-white"
+          >
+            Modern, proven, future-proof
+          </motion.h2>
+          <motion.p
+            variants={fadeUp}
+            className="text-gray-500 dark:text-gray-400 text-center max-w-lg mx-auto mb-12 text-base"
+          >
+            We use the same stack as the fastest-growing SaaS companies — not legacy frameworks.
+          </motion.p>
+
+          <div className="flex flex-wrap justify-center gap-3">
+            {STACK.map((item, i) => (
+              <motion.div
+                key={i}
+                variants={fadeUp}
+                className="flex flex-col items-center gap-1.5"
+              >
+                <span className={`px-4 py-2 rounded-full text-sm font-bold ${item.color}`}>
+                  {item.name}
+                </span>
+                <span className="text-[10px] text-gray-400 dark:text-gray-600 uppercase tracking-widest font-semibold">
+                  {item.tag}
+                </span>
+              </motion.div>
+            ))}
+          </div>
+        </motion.div>
+      </div>
+    </section>
+  );
+}

--- a/app/pages/saas-website-design/_components/what-we-build-section.tsx
+++ b/app/pages/saas-website-design/_components/what-we-build-section.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import React, { useRef } from 'react';
+import { motion, useInView } from 'framer-motion';
+import { Globe, FileText, DollarSign, BookOpen, LayoutTemplate, Rocket } from 'lucide-react';
+
+const DELIVERABLES = [
+  {
+    icon: <Globe className="h-5 w-5" />,
+    title: 'Marketing homepage',
+    desc: 'Hero, features, social proof, pricing, CTA — built to rank and convert.',
+    color: 'bg-indigo-50 text-indigo-600 dark:bg-indigo-900/30 dark:text-indigo-400',
+  },
+  {
+    icon: <DollarSign className="h-5 w-5" />,
+    title: 'Pricing page',
+    desc: 'Feature tables, toggle plans, FAQs, and conversion-optimised CTA blocks.',
+    color: 'bg-green-50 text-green-600 dark:bg-green-900/30 dark:text-green-400',
+  },
+  {
+    icon: <LayoutTemplate className="h-5 w-5" />,
+    title: 'PPC landing pages',
+    desc: 'Single-purpose pages for Google Ads and LinkedIn — A/B test ready.',
+    color: 'bg-violet-50 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400',
+  },
+  {
+    icon: <BookOpen className="h-5 w-5" />,
+    title: 'Docs & help centre',
+    desc: 'MDX-powered docs sites with search, versioning, and on-brand styling.',
+    color: 'bg-amber-50 text-amber-600 dark:bg-amber-900/30 dark:text-amber-400',
+  },
+  {
+    icon: <FileText className="h-5 w-5" />,
+    title: 'Blog & content hub',
+    desc: 'SEO-targeted blog with CMS, structured data, and internal linking architecture.',
+    color: 'bg-rose-50 text-rose-600 dark:bg-rose-900/30 dark:text-rose-400',
+  },
+  {
+    icon: <Rocket className="h-5 w-5" />,
+    title: 'Launch & waitlist pages',
+    desc: 'Pre-launch pages with email capture, countdown, and viral referral hooks.',
+    color: 'bg-sky-50 text-sky-600 dark:bg-sky-900/30 dark:text-sky-400',
+  },
+];
+
+const fadeUp = {
+  hidden: { opacity: 0, y: 20 },
+  show: { opacity: 1, y: 0, transition: { duration: 0.5, ease: 'easeOut' } },
+};
+
+export function WhatWeBuildSection() {
+  const ref = useRef<HTMLDivElement>(null);
+  const inView = useInView(ref, { once: true, amount: 0.2 });
+
+  return (
+    <section
+      ref={ref}
+      id="services"
+      className="py-20 md:py-28 bg-gray-50 dark:bg-gray-900"
+    >
+      <div className="container mx-auto px-4 max-w-6xl">
+        <motion.div
+          initial="hidden"
+          animate={inView ? 'show' : 'hidden'}
+          variants={{ show: { transition: { staggerChildren: 0.09 } } }}
+        >
+          <motion.p
+            variants={fadeUp}
+            className="text-xs uppercase tracking-widest text-indigo-600 dark:text-indigo-400 font-bold mb-3 text-center"
+          >
+            What we build
+          </motion.p>
+          <motion.h2
+            variants={fadeUp}
+            className="text-3xl sm:text-4xl md:text-5xl font-black tracking-tight text-center mb-4 text-gray-900 dark:text-white"
+          >
+            Every surface your SaaS needs
+          </motion.h2>
+          <motion.p
+            variants={fadeUp}
+            className="text-gray-500 dark:text-gray-400 text-center max-w-xl mx-auto mb-14 text-base"
+          >
+            We cover the full marketing-site stack — from your hero to your help centre.
+          </motion.p>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+            {DELIVERABLES.map((item, i) => (
+              <motion.div
+                key={i}
+                variants={fadeUp}
+                className="p-6 bg-white dark:bg-gray-800 rounded-2xl border border-gray-100 dark:border-gray-700 hover:shadow-md transition-shadow duration-200"
+              >
+                <div className={`inline-flex p-2.5 rounded-xl mb-4 ${item.color}`}>
+                  {item.icon}
+                </div>
+                <h3 className="font-bold text-gray-900 dark:text-white mb-1.5 text-base">
+                  {item.title}
+                </h3>
+                <p className="text-sm text-gray-500 dark:text-gray-400 leading-relaxed">
+                  {item.desc}
+                </p>
+              </motion.div>
+            ))}
+          </div>
+        </motion.div>
+      </div>
+    </section>
+  );
+}

--- a/app/pages/saas-website-design/_components/why-us-section.tsx
+++ b/app/pages/saas-website-design/_components/why-us-section.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import React, { useRef } from 'react';
+import { motion, useInView } from 'framer-motion';
+import { CheckCircle } from 'lucide-react';
+
+const POINTS = [
+  {
+    title: 'Design-led, not template-driven',
+    desc: 'Every pixel is intentional. We reference Linear, Vercel, and Stripe — not Wix themes.',
+  },
+  {
+    title: 'Built for speed — literally',
+    desc: 'Next.js App Router, next/image, font subsetting, and Lighthouse-first development. 95+ score is our floor.',
+  },
+  {
+    title: 'SEO from line 1',
+    desc: 'Semantic HTML, schema.org JSON-LD, sitemap, canonicals, and OG tags ship with every page.',
+  },
+  {
+    title: 'Conversion architecture',
+    desc: 'CTA hierarchy, social proof placement, objection handling, and micro-copy informed by SaaS best practices.',
+  },
+  {
+    title: 'Analytics wired in',
+    desc: 'GA4 events, HubSpot forms, Intercom chat, Segment, and custom conversion tracking — configured, not hacked together.',
+  },
+  {
+    title: 'Handoff or ongoing partner',
+    desc: 'We hand off clean code and a Notion wiki, or stay on as your growth engineering partner.',
+  },
+];
+
+const fadeUp = {
+  hidden: { opacity: 0, y: 20 },
+  show: { opacity: 1, y: 0, transition: { duration: 0.5, ease: 'easeOut' } },
+};
+
+export function WhyUsSection() {
+  const ref = useRef<HTMLDivElement>(null);
+  const inView = useInView(ref, { once: true, amount: 0.2 });
+
+  return (
+    <section
+      ref={ref}
+      className="py-20 md:py-28 bg-white dark:bg-gray-950"
+    >
+      <div className="container mx-auto px-4 max-w-6xl">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 lg:gap-20 items-center">
+
+          {/* Left copy */}
+          <motion.div
+            initial="hidden"
+            animate={inView ? 'show' : 'hidden'}
+            variants={{ show: { transition: { staggerChildren: 0.1 } } }}
+          >
+            <motion.p
+              variants={fadeUp}
+              className="text-xs uppercase tracking-widest text-indigo-600 dark:text-indigo-400 font-bold mb-3"
+            >
+              Why Vedpragya
+            </motion.p>
+            <motion.h2
+              variants={fadeUp}
+              className="text-3xl sm:text-4xl md:text-5xl font-black tracking-tight mb-5 text-gray-900 dark:text-white leading-tight"
+            >
+              We think like{' '}
+              <span className="text-indigo-600 dark:text-indigo-400">SaaS founders</span>,<br />
+              build like engineers
+            </motion.h2>
+            <motion.p
+              variants={fadeUp}
+              className="text-gray-500 dark:text-gray-400 text-base leading-relaxed max-w-lg"
+            >
+              Most agencies hand you a pretty Figma file and leave you to figure out the rest.
+              We own the full stack — strategy, design, development, and analytics — and we
+              measure success in signups, not screenshots.
+            </motion.p>
+          </motion.div>
+
+          {/* Right checklist */}
+          <motion.ul
+            initial="hidden"
+            animate={inView ? 'show' : 'hidden'}
+            variants={{ show: { transition: { staggerChildren: 0.08 } } }}
+            className="space-y-4"
+          >
+            {POINTS.map((point, i) => (
+              <motion.li
+                key={i}
+                variants={fadeUp}
+                className="flex gap-3 p-4 rounded-xl border border-gray-100 dark:border-gray-800 bg-gray-50 dark:bg-gray-900"
+              >
+                <CheckCircle className="h-5 w-5 text-indigo-500 flex-shrink-0 mt-0.5" />
+                <div>
+                  <p className="font-bold text-gray-900 dark:text-white text-sm">{point.title}</p>
+                  <p className="text-gray-500 dark:text-gray-400 text-sm mt-0.5 leading-relaxed">
+                    {point.desc}
+                  </p>
+                </div>
+              </motion.li>
+            ))}
+          </motion.ul>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/app/pages/saas-website-design/layout.tsx
+++ b/app/pages/saas-website-design/layout.tsx
@@ -1,0 +1,104 @@
+import { ReactNode } from 'react';
+import { Metadata } from 'next';
+import { buildPageMetadata } from '@/app/lib/seo/metadata';
+import { companyProfile } from '@/app/data/companyProfile';
+import { BreadcrumbStructuredData, FAQStructuredData } from '@/app/components/SEO/StructuredData';
+import { SEO_SITE_URL, toAbsoluteSeoUrl } from '@/app/lib/seo/constants';
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'SaaS Website Design Agency | High-Converting SaaS Marketing Sites',
+  description:
+    'We design and build SaaS marketing websites, landing pages, and docs sites that convert visitors into paying users. Next.js + Framer Motion. India-based, global clients.',
+  path: '/pages/saas-website-design',
+  keywords: [
+    'saas website design agency',
+    'saas landing page design',
+    'saas web design company',
+    'saas marketing website design',
+    'saas product website',
+    'saas website design india',
+    'hire saas web designer',
+    'saas website development',
+    'saas website design company india',
+    'startup website design agency',
+    'saas product landing page',
+    'nextjs saas website',
+    'framer saas website',
+    'saas homepage design',
+    'b2b saas website design',
+  ],
+});
+
+const FAQ_QUESTIONS = [
+  {
+    question: 'What makes a great SaaS marketing website?',
+    answer:
+      'A great SaaS website has a crystal-clear value proposition above the fold, social proof (logos, testimonials, case studies), feature walkthroughs that address objections, and a frictionless CTA flow. It loads in under 2 seconds and scores 90+ on Core Web Vitals. We build all of this with Next.js and Tailwind.',
+  },
+  {
+    question: 'How much does SaaS website design cost in India?',
+    answer:
+      'A high-quality SaaS marketing website starts at ₹80,000 for a 5-page site (homepage, pricing, features, about, contact). A full design system with landing pages, docs integration, and blog starts at ₹2,50,000. Enterprise-grade sites with custom animations and CMS are priced on request.',
+  },
+  {
+    question: 'How long does it take to build a SaaS website?',
+    answer:
+      'A focused SaaS homepage with core marketing pages takes 3–4 weeks. A full marketing site with blog, docs, pricing, changelog, and CMS integration takes 6–10 weeks. We work in two-week sprints with design-then-code handoff.',
+  },
+  {
+    question: 'Do you design or just develop?',
+    answer:
+      'Both. We handle strategy, UX wireframes, visual design, and development end-to-end. If you already have Figma designs, we can build pixel-perfect from them. We align to your brand or create a new design system from scratch.',
+  },
+  {
+    question: 'Can you integrate our SaaS website with HubSpot, Intercom, or our app?',
+    answer:
+      'Yes. We integrate analytics (GA4, Mixpanel, Segment), CRM and marketing automation (HubSpot, Intercom, Customer.io), auth redirects to your product, and custom webhook pipelines. If your app has an API, we can connect to it.',
+  },
+  {
+    question: 'Will the site rank on Google?',
+    answer:
+      'SEO is built in, not bolted on. Every page ships with canonical tags, JSON-LD structured data, semantic HTML, next/image optimization, sitemap.xml, and a robots.txt. We also help plan your content architecture so the site can earn organic traffic over time.',
+  },
+];
+
+const structuredData = {
+  '@context': 'https://schema.org',
+  '@type': 'Service',
+  name: 'SaaS Website Design & Development',
+  description:
+    'End-to-end SaaS website design and development — marketing sites, landing pages, pricing pages, and docs sites built with Next.js and Tailwind.',
+  provider: {
+    '@type': 'Organization',
+    name: companyProfile.legalName,
+    url: companyProfile.websiteUrl,
+    logo: toAbsoluteSeoUrl('/logo.png'),
+  },
+  areaServed: { '@type': 'Place', name: 'Worldwide' },
+  serviceType: 'SaaS Website Design',
+  offers: {
+    '@type': 'Offer',
+    priceCurrency: 'INR',
+    availability: 'https://schema.org/InStock',
+  },
+};
+
+export default function SaasWebsiteDesignLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <BreadcrumbStructuredData
+        items={[
+          { name: 'Home', url: SEO_SITE_URL },
+          { name: 'Services', url: `${SEO_SITE_URL}/pages/services` },
+          { name: 'SaaS Website Design', url: `${SEO_SITE_URL}/pages/saas-website-design` },
+        ]}
+      />
+      <FAQStructuredData questions={FAQ_QUESTIONS} />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
+      {children}
+    </>
+  );
+}

--- a/app/pages/saas-website-design/page.tsx
+++ b/app/pages/saas-website-design/page.tsx
@@ -1,0 +1,21 @@
+import { HeroSection } from './_components/hero-section';
+import { WhatWeBuildSection } from './_components/what-we-build-section';
+import { WhyUsSection } from './_components/why-us-section';
+import { TechStackSection } from './_components/tech-stack-section';
+import { LeadFormSection } from './_components/lead-form-section';
+import { FAQSection } from './_components/faq-section';
+import { FinalCtaSection } from './_components/final-cta-section';
+
+export default function SaasWebsiteDesignPage() {
+  return (
+    <main className="min-h-screen">
+      <HeroSection />
+      <WhatWeBuildSection />
+      <WhyUsSection />
+      <TechStackSection />
+      <LeadFormSection />
+      <FAQSection />
+      <FinalCtaSection />
+    </main>
+  );
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -35,6 +35,7 @@ const HIGH_PRIORITY_SERVICE_ROUTES = new Set([
   '/pages/next-js-development',
   '/pages/reactjs-development',
   '/pages/nodejs-development',
+  '/pages/saas-website-design',
   '/pages/ai-chatbot-development',
   '/pages/ai-voice-agents',
   '/pages/whatsapp-business-api',


### PR DESCRIPTION
## Summary

- New route `/pages/saas-website-design` — targets "saas website design agency" keyword cluster, a high-intent, high-ACV segment not previously covered
- 7 sections: hero, what-we-build, why-us, tech stack, lead form, FAQ, final CTA
- Lead form wired to `/api/lead` with `source: saas-website-design` — writes to DB, triggers Zoho sync + Google Ads conversion event (`saas_website_design_lead_submit`)
- Structured data in `layout.tsx`: Service schema, FAQ schema (6 Q&As), BreadcrumbList
- 15 target keywords in metadata: `saas website design agency`, `saas landing page design`, `saas web design company india`, `startup website design agency`, and more
- Registered in `app/lib/seo/routes.ts` (both `CORE_STATIC_ROUTES` and `ALL_STATIC_PAGE_ROUTES`) and added to `HIGH_PRIORITY_SERVICE_ROUTES` in `app/sitemap.ts` at priority 0.90

## Test plan

- [ ] Visit `/pages/saas-website-design` — all 7 sections render without errors
- [ ] Submit lead form — confirm entry appears in admin DB with `source: saas-website-design`
- [ ] Check `/sitemap.xml` includes the new URL at priority 0.90
- [ ] Verify `<title>` and meta description render correctly in page source
- [ ] Confirm JSON-LD structured data present in `<head>`

https://claude.ai/code/session_01ToWhhD5xSbmAQVezgVhbiA

---
_Generated by [Claude Code](https://claude.ai/code/session_01ToWhhD5xSbmAQVezgVhbiA)_