### PR TITLE
SEO: add per-post metadata and Article JSON-LD to blog pages

### DIFF
--- a/app/pages/blog/[slug]/page.tsx
+++ b/app/pages/blog/[slug]/page.tsx
@@ -1,11 +1,15 @@
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import type { Metadata } from 'next';
 import {
   getBlogPost,
   getBlogPostSlugs,
   getRelatedBlogPosts,
   getCategoryServiceLink,
 } from '@/app/lib/blog';
+import { buildPageMetadata } from '@/app/lib/seo/metadata';
+import { SEO_SITE_URL, toAbsoluteSeoUrl } from '@/app/lib/seo/constants';
+import { ArticleStructuredData } from '@/app/components/SEO/StructuredData';
 
 interface PageProps {
   params: Promise<{ slug: string }>;
@@ -19,6 +23,26 @@ export async function generateStaticParams() {
   const slugs = getBlogPostSlugs();
   console.log('[Blog] generateStaticParams', { count: slugs.length });
   return slugs.map((slug) => ({ slug }));
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const post = await getBlogPost(slug);
+
+  if (!post) {
+    return {};
+  }
+
+  const canonicalPath = `/pages/blog/${post.slug}`;
+  const ogImage = post.image ?? '/og-default.jpg';
+
+  return buildPageMetadata({
+    title: `${post.title} | Vedpragya`,
+    description: post.excerpt,
+    path: canonicalPath,
+    imagePath: ogImage,
+    ogType: 'article',
+  });
 }
 
 function formatDate(dateString: string) {
@@ -43,6 +67,17 @@ export default async function BlogPostPage({ params }: PageProps) {
 
   return (
     <div className="w-full">
+      <ArticleStructuredData
+        headline={post.title}
+        image={post.image ? toAbsoluteSeoUrl(post.image) : toAbsoluteSeoUrl('/og-default.jpg')}
+        datePublished={post.publishedAt}
+        dateModified={post.updatedAt ?? post.publishedAt}
+        author={{ name: post.author, url: SEO_SITE_URL }}
+        publisher={{ name: 'Vedpragya', logo: toAbsoluteSeoUrl('/icon.png') }}
+        description={post.excerpt}
+        url={toAbsoluteSeoUrl(`/pages/blog/${post.slug}`)}
+      />
+
       {/* Hero Section */}
       <section className="relative py-20 bg-gradient-to-br from-gray-900 to-gray-800 text-white">
         <div className="container mx-auto px-4">


### PR DESCRIPTION
## Summary

- All 24 blog posts were inheriting the root layout's generic title ("Web Development, AI & Google Ads Agency India | Vedpragya") and a canonical pointing to `/` — making every post indistinguishable to Googlebot
- Added `generateMetadata` to `app/pages/blog/[slug]/page.tsx` that builds per-post title, meta description, canonical URL, and OG image
- Added `ArticleStructuredData` (JSON-LD) to each rendered post so Google recognises article type, author, and publish/update dates

## Impact

24 blog posts go from zero unique signals in SERPs to full indexable metadata. This unblocks Google from distinguishing and ranking individual posts.

## Test plan

- [ ] Build (`npm run build`) — verify `generateStaticParams` and `generateMetadata` both run without errors for each slug
- [ ] Spot-check `/pages/blog/web-development-cost-india-2025` — confirm `<title>` and canonical match the post, not the root
- [ ] Rich-results test on a post URL — Article structured data should validate

https://claude.ai/code/session_01HmDPvL4WNgUUTNGbNEJkfE

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmDPvL4WNgUUTNGbNEJkfE)_