### PR TITLE
SEO: add per-post metadata to blog detail and list pages

### DIFF
--- a/app/pages/blog/[slug]/page.tsx
+++ b/app/pages/blog/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import {
@@ -6,9 +7,39 @@ import {
   getRelatedBlogPosts,
   getCategoryServiceLink,
 } from '@/app/lib/blog';
+import { buildPageMetadata } from '@/app/lib/seo/metadata';
 
 interface PageProps {
   params: Promise<{ slug: string }>;
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const post = await getBlogPost(slug);
+
+  if (!post) {
+    return { title: 'Post Not Found | Vedpragya Blog' };
+  }
+
+  const base = buildPageMetadata({
+    title: `${post.title} | Vedpragya Blog`,
+    description: post.excerpt,
+    path: `/pages/blog/${post.slug}`,
+    keywords: post.tags,
+    ogType: 'article',
+  });
+
+  return {
+    ...base,
+    openGraph: {
+      ...base.openGraph,
+      type: 'article',
+      publishedTime: new Date(post.publishedAt).toISOString(),
+      ...(post.updatedAt ? { modifiedTime: new Date(post.updatedAt).toISOString() } : {}),
+      authors: [post.author],
+      tags: post.tags,
+    },
+  };
 }
 
 /**

--- a/app/pages/blog/page.tsx
+++ b/app/pages/blog/page.tsx
@@ -1,5 +1,22 @@
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import { getAllBlogPosts, getAllBlogCategories } from '@/app/lib/blog';
+import { buildPageMetadata } from '@/app/lib/seo/metadata';
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Web Development & AI Blog India | Vedpragya',
+  description:
+    'Practical guides on web development, AI chatbots, Next.js, Shopify, Google Ads, and digital growth for Indian businesses. Written by Vedpragya engineers.',
+  path: '/pages/blog',
+  keywords: [
+    'web development blog india',
+    'nextjs tutorial india',
+    'ai chatbot development guide',
+    'shopify development india',
+    'google ads tips india',
+    'software development blog',
+  ],
+});
 
 /**
  * Blog listing page.


### PR DESCRIPTION
## Summary

- **Blog detail page** (`/pages/blog/[slug]`): adds `generateMetadata` that emits a unique `<title>`, `<meta description>`, canonical URL, `og:type=article` with `publishedTime`/`modifiedTime`/`authors`, and post-specific tags for every one of the 24 existing blog posts
- **Blog list page** (`/pages/blog`): adds a static `metadata` export with keyword-targeted title and description
- Uses the existing `buildPageMetadata` helper for consistency with every other page on the site

## Why this matters

All 24 blog posts were inheriting the site's root layout metadata — every post shared the same generic title ("Vedpragya | Software Development & IT Solutions Company — India") and description in SERPs. This kills CTR even if a post ranks, and prevents Google from generating meaningful SERP snippets. This fix unlocks proper indexation for all existing and future blog content.

## Test plan

- [ ] Build succeeds (`npm run build`)
- [ ] `curl -s https://vedpragya.com/pages/blog/how-to-hire-web-development-company-india | grep "<title>"` returns the post-specific title
- [ ] `curl -s https://vedpragya.com/pages/blog | grep "<title>"` returns the blog list title
- [ ] OG tags on any blog post show `og:type=article` and post-specific `og:title`/`og:description`

https://claude.ai/code/session_018ezVhHvkCFxb5HVuvcT7Kd

---
_Generated by [Claude Code](https://claude.ai/code/session_018ezVhHvkCFxb5HVuvcT7Kd)_