### PR TITLE
feat: inline lead capture form on all city landing pages

### DIFF
--- a/app/components/CityLandingPage.tsx
+++ b/app/components/CityLandingPage.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import type { ReactElement } from 'react';
 import { RelatedServicesStrip } from '@/app/components/RelatedServicesStrip';
+import { CityLeadForm } from '@/app/components/CityLeadForm';
 
 /**
  * Shared city landing page component.
@@ -74,7 +75,7 @@ export function CityLandingPage({
             </p>
             <div className="flex flex-wrap gap-4 justify-center">
               <Link
-                href="/pages/contact"
+                href="#get-proposal"
                 className="px-8 py-4 bg-blue-500 hover:bg-blue-600 text-white rounded-full font-semibold transition"
               >
                 Get a Free Proposal
@@ -298,8 +299,51 @@ export function CityLandingPage({
         </div>
       </section>
 
+      {/* Inline Lead Capture Form */}
+      <section id="get-proposal" className="py-20 bg-white dark:bg-gray-950">
+        <div className="container mx-auto px-4 max-w-5xl">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-start">
+            {/* Left: value prop */}
+            <div>
+              <p className="uppercase tracking-widest text-sm text-blue-600 dark:text-blue-400 font-semibold mb-3">
+                Free Consultation
+              </p>
+              <h2 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-4">
+                Get a Written Proposal for Your {cityName} Project
+              </h2>
+              <p className="text-lg text-gray-600 dark:text-gray-300 mb-8">
+                Share your requirements and we&apos;ll send a fixed-price quote with
+                scope, timeline, and team composition — usually within 2 business hours.
+              </p>
+              <ul className="space-y-3">
+                {[
+                  'Fixed-scope quotes. No hourly surprises.',
+                  'INR pricing. GST invoice included.',
+                  'Dedicated project manager from day one.',
+                  '100% remote — video calls during IST hours.',
+                ].map((point) => (
+                  <li key={point} className="flex items-start gap-3 text-gray-700 dark:text-gray-300">
+                    <span className="mt-1 flex-shrink-0 w-5 h-5 rounded-full bg-blue-100 dark:bg-blue-900/40 flex items-center justify-center">
+                      <svg className="w-3 h-3 text-blue-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
+                      </svg>
+                    </span>
+                    {point}
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            {/* Right: form */}
+            <div className="bg-gray-50 dark:bg-gray-900 rounded-2xl p-8 border border-gray-100 dark:border-gray-800">
+              <CityLeadForm cityName={cityName} citySlug={citySlug} />
+            </div>
+          </div>
+        </div>
+      </section>
+
       {/* CTA */}
-      <section className="py-20 bg-blue-600 text-white">
+      <section className="py-16 bg-blue-600 text-white">
         <div className="container mx-auto px-4 text-center max-w-3xl">
           <h2 className="text-3xl md:text-4xl font-bold mb-4">
             Ready to Build Your Website?
@@ -311,7 +355,7 @@ export function CityLandingPage({
           </p>
           <div className="flex flex-wrap gap-4 justify-center">
             <Link
-              href="/pages/contact"
+              href="#get-proposal"
               className="inline-block px-8 py-4 bg-white text-blue-600 hover:bg-gray-100 rounded-full font-semibold transition"
             >
               Book a Free Consultation

--- a/app/components/CityLeadForm.tsx
+++ b/app/components/CityLeadForm.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import { useState } from 'react';
+
+interface CityLeadFormProps {
+  cityName: string;
+  citySlug: string;
+}
+
+export function CityLeadForm({ cityName, citySlug }: CityLeadFormProps) {
+  const [form, setForm] = useState({ name: '', phone: '', email: '', budget: '', message: '' });
+  const [status, setStatus] = useState<'idle' | 'submitting' | 'success' | 'error'>('idle');
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
+    setForm((prev) => ({ ...prev, [e.target.name]: e.target.value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!form.name.trim() || !form.phone.trim()) return;
+    setStatus('submitting');
+    try {
+      const res = await fetch('/api/lead', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: form.name,
+          phone: form.phone,
+          email: form.email || undefined,
+          message: form.message || undefined,
+          budget: form.budget || undefined,
+          source: `web-development-${citySlug}`,
+          leadSource: `${cityName} Web Development Page`,
+          raw: {
+            path: typeof window !== 'undefined' ? window.location.pathname : undefined,
+            referrer: typeof document !== 'undefined' ? document.referrer : undefined,
+          },
+        }),
+      });
+      if (!res.ok) throw new Error('failed');
+      setStatus('success');
+    } catch {
+      setStatus('error');
+    }
+  };
+
+  if (status === 'success') {
+    return (
+      <div className="text-center py-8">
+        <div className="inline-flex items-center justify-center w-16 h-16 bg-green-100 dark:bg-green-900/30 rounded-full mb-4">
+          <svg className="w-8 h-8 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+          </svg>
+        </div>
+        <h3 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">We&apos;ll be in touch shortly</h3>
+        <p className="text-gray-600 dark:text-gray-300">Our team typically responds within 2 hours during business hours.</p>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} noValidate className="space-y-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div>
+          <label htmlFor="city-name" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            Your Name <span className="text-red-500">*</span>
+          </label>
+          <input
+            id="city-name"
+            name="name"
+            type="text"
+            required
+            value={form.name}
+            onChange={handleChange}
+            placeholder="Rajesh Kumar"
+            className="w-full px-4 py-3 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition"
+          />
+        </div>
+        <div>
+          <label htmlFor="city-phone" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            Phone Number <span className="text-red-500">*</span>
+          </label>
+          <input
+            id="city-phone"
+            name="phone"
+            type="tel"
+            required
+            value={form.phone}
+            onChange={handleChange}
+            placeholder="+91 98765 43210"
+            className="w-full px-4 py-3 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition"
+          />
+        </div>
+      </div>
+
+      <div>
+        <label htmlFor="city-email" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+          Email Address
+        </label>
+        <input
+          id="city-email"
+          name="email"
+          type="email"
+          value={form.email}
+          onChange={handleChange}
+          placeholder="you@yourcompany.com"
+          className="w-full px-4 py-3 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="city-budget" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+          Approx. Budget
+        </label>
+        <select
+          id="city-budget"
+          name="budget"
+          value={form.budget}
+          onChange={handleChange}
+          className="w-full px-4 py-3 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition"
+        >
+          <option value="">Select budget range</option>
+          <option value="₹15K-30K">₹15,000 – ₹30,000</option>
+          <option value="₹30K-60K">₹30,000 – ₹60,000</option>
+          <option value="₹60K-1L">₹60,000 – ₹1,00,000</option>
+          <option value="₹1L-2L">₹1,00,000 – ₹2,00,000</option>
+          <option value="₹2L+">₹2,00,000+</option>
+          <option value="not-decided">Not decided yet</option>
+        </select>
+      </div>
+
+      <div>
+        <label htmlFor="city-message" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+          Brief Requirement
+        </label>
+        <textarea
+          id="city-message"
+          name="message"
+          rows={3}
+          value={form.message}
+          onChange={handleChange}
+          placeholder={`What kind of website do you need in ${cityName}?`}
+          className="w-full px-4 py-3 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition resize-none"
+        />
+      </div>
+
+      {status === 'error' && (
+        <p className="text-sm text-red-600 dark:text-red-400">
+          Something went wrong. Please try again or call us directly.
+        </p>
+      )}
+
+      <button
+        type="submit"
+        disabled={status === 'submitting' || !form.name.trim() || !form.phone.trim()}
+        className="w-full px-8 py-4 bg-blue-600 hover:bg-blue-700 disabled:opacity-60 disabled:cursor-not-allowed text-white rounded-xl font-semibold text-lg transition"
+      >
+        {status === 'submitting' ? 'Sending…' : 'Get a Free Proposal'}
+      </button>
+
+      <p className="text-xs text-center text-gray-400 dark:text-gray-500">
+        No spam. We respond within 2 business hours.
+      </p>
+    </form>
+  );
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -64,13 +64,13 @@ const ROUTE_LAST_MODIFIED_MAP: Record<string, Date> = {
   '/pages/shopify-headless-migration': new Date('2026-04-14T00:00:00.000Z'),
   '/pages/shopify-product-page-customization': new Date('2026-04-14T00:00:00.000Z'),
 
-  // New city landing pages launched in April 2026 SEO pass
-  '/pages/web-development-delhi': new Date('2026-04-14T00:00:00.000Z'),
-  '/pages/web-development-bangalore': new Date('2026-04-14T00:00:00.000Z'),
-  '/pages/web-development-gurgaon': new Date('2026-04-14T00:00:00.000Z'),
-  '/pages/web-development-pune': new Date('2026-04-14T00:00:00.000Z'),
-  '/pages/web-development-hyderabad': new Date('2026-04-14T00:00:00.000Z'),
-  '/pages/web-development-noida': new Date('2026-04-14T00:00:00.000Z'),
+  // City landing pages — updated April 2026 with inline lead capture form
+  '/pages/web-development-delhi': new Date('2026-04-29T00:00:00.000Z'),
+  '/pages/web-development-bangalore': new Date('2026-04-29T00:00:00.000Z'),
+  '/pages/web-development-gurgaon': new Date('2026-04-29T00:00:00.000Z'),
+  '/pages/web-development-pune': new Date('2026-04-29T00:00:00.000Z'),
+  '/pages/web-development-hyderabad': new Date('2026-04-29T00:00:00.000Z'),
+  '/pages/web-development-noida': new Date('2026-04-29T00:00:00.000Z'),
   '/pages/nodejs-development': new Date('2026-04-14T00:00:00.000Z'),
 
   // Legal pages — stable; use a fixed baseline date to avoid false freshness signals


### PR DESCRIPTION
## Summary

- **Conversion gap fixed:** 5 city pages (Delhi, Bangalore, Gurgaon, Noida, Pune, Hyderabad) had zero on-page lead capture — all CTAs redirected to `/pages/contact`, losing conversion intent with no DB record created
- **New `CityLeadForm` client component** (`app/components/CityLeadForm.tsx`) — collects name, phone, email, budget, and requirement, POSTs to `/api/lead` with city-specific `source` tagging (e.g. `web-development-delhi`), feeding the full Zoho CRM + Google Ads conversion pipeline
- **`CityLandingPage.tsx` updated** — imports and renders `CityLeadForm` in a new `#get-proposal` section; hero and final-CTA anchor links now scroll to the inline form instead of navigating off-page to `/pages/contact`
- **Sitemap `lastModified` updated** for all 6 city routes to signal fresh content to Googlebot

## Test plan

- [ ] Visit `/pages/web-development-delhi` (or any city page) — confirm the "Get a Free Proposal" form renders inline
- [ ] Submit form with name + phone → verify `Lead` row created in DB with `source = 'web-development-delhi'`
- [ ] Submit with empty required fields → confirm button stays disabled
- [ ] Confirm success state renders after valid submission
- [ ] Check `/sitemap.xml` — city routes show updated `lastmod` of `2026-04-29`

https://claude.ai/code/session_01UpQbMAauFCjyjYCsKaUmUw

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpQbMAauFCjyjYCsKaUmUw)_