### PR TITLE
feat(seo): page-level metadata + FAQ schema for web-development and about pages

### DIFF
--- a/app/pages/about/page.tsx
+++ b/app/pages/about/page.tsx
@@ -1,28 +1,23 @@
 import type { Metadata } from "next";
+import { buildPageMetadata } from '@/app/lib/seo/metadata';
 import Link from "next/link";
 import { BackgroundBeams } from "@/app/components/ui/background-beams";
 import { Spotlight } from "@/app/components/ui/spotlight";
 import { MovingBorder } from "@/app/components/ui/moving-border";
 
-export const metadata: Metadata = {
+export const metadata: Metadata = buildPageMetadata({
   title: 'About Vedpragya | Engineering-First Software Agency — India',
   description: 'Vedpragya Bharat Private Limited is an engineering-first software agency founded in Haryana, India. 500+ projects delivered across web, AI, ERP, and e-commerce for clients in India, UAE, USA, and Canada.',
-  keywords: 'about vedpragya, software agency india, web development company about, vedpragya bharat private limited, aman kumar sharma, software engineering firm india',
-  alternates: {
-    canonical: '/pages/about',
-  },
-  openGraph: {
-    title: 'About Vedpragya | Engineering-First Software Agency',
-    description: 'Founded in Haryana, India. 500+ projects. Offices in India, UAE, USA, Canada, and China. We build software that outlives the projects that spawn it.',
-    url: 'https://vedpragya.com/pages/about',
-    type: 'website',
-  },
-  twitter: {
-    card: 'summary_large_image',
-    title: 'About Vedpragya | Engineering-First Software Agency',
-    description: 'Founded in Haryana, India. 500+ projects. Engineering-first, transparency-always.',
-  },
-};
+  path: '/pages/about',
+  keywords: [
+    'about vedpragya',
+    'software agency india',
+    'web development company about',
+    'vedpragya bharat private limited',
+    'aman kumar sharma',
+    'software engineering firm india',
+  ],
+});
 
 const milestones = [
   { year: "2025", event: "Founded", desc: "Vedpragya Bharat Private Limited was founded in Haryana, India by Aman Kumar Sharma." },

--- a/app/pages/about/page.tsx
+++ b/app/pages/about/page.tsx
@@ -1,7 +1,28 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 import { BackgroundBeams } from "@/app/components/ui/background-beams";
 import { Spotlight } from "@/app/components/ui/spotlight";
 import { MovingBorder } from "@/app/components/ui/moving-border";
+
+export const metadata: Metadata = {
+  title: 'About Vedpragya | Engineering-First Software Agency — India',
+  description: 'Vedpragya Bharat Private Limited is an engineering-first software agency founded in Haryana, India. 500+ projects delivered across web, AI, ERP, and e-commerce for clients in India, UAE, USA, and Canada.',
+  keywords: 'about vedpragya, software agency india, web development company about, vedpragya bharat private limited, aman kumar sharma, software engineering firm india',
+  alternates: {
+    canonical: '/pages/about',
+  },
+  openGraph: {
+    title: 'About Vedpragya | Engineering-First Software Agency',
+    description: 'Founded in Haryana, India. 500+ projects. Offices in India, UAE, USA, Canada, and China. We build software that outlives the projects that spawn it.',
+    url: 'https://vedpragya.com/pages/about',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'About Vedpragya | Engineering-First Software Agency',
+    description: 'Founded in Haryana, India. 500+ projects. Engineering-first, transparency-always.',
+  },
+};
 
 const milestones = [
   { year: "2025", event: "Founded", desc: "Vedpragya Bharat Private Limited was founded in Haryana, India by Aman Kumar Sharma." },

--- a/app/pages/web-development/page.tsx
+++ b/app/pages/web-development/page.tsx
@@ -1,11 +1,9 @@
-// Web Development Landing Page
-// This page composes multiple premium sections into a high-converting layout.
-// It relies on reusable sections already used elsewhere in the codebase + two new sections (services grid, pricing).
-
+import type { Metadata } from "next";
 import React from "react";
 import { SectionErrorBoundary } from "@/app/components/common/SectionErrorBoundary";
 import { RelatedBlogPosts } from "@/app/components/RelatedBlogPosts";
 import { RelatedServicesStrip } from "@/app/components/RelatedServicesStrip";
+import { FAQStructuredData } from "@/app/components/SEO/StructuredData";
 import { HeroSection as WDHero } from "@/app/pages/website-development/_components/hero-section";
 import { ServicesGridSection } from "@/app/pages/web-development/_components/services-grid-section";
 import { ServicesSection as WDServices } from "@/app/pages/website-development/_components/services-section";
@@ -16,9 +14,50 @@ import { FAQSection as WDFAQ } from "@/app/pages/website-development/_components
 import { AnimatedBannerCta as WDBannerCta } from "@/app/pages/website-development/_components/animated-banner-cta";
 import { ContactSection as WDContact } from "@/app/pages/website-development/_components/contact-section";
 
+export const metadata: Metadata = {
+  title: 'Web Development Company India | Custom Websites & Web Apps — Vedpragya',
+  description: 'Vedpragya is a web development company in India specialising in Next.js, React, Node.js, SaaS apps, e-commerce, and enterprise web solutions. 500+ projects delivered. Free consultation in 24 h.',
+  keywords: 'web development company india, web development services, hire web developer india, next.js development, react development, node.js development, custom web app development, saas development india, web development agency',
+  alternates: {
+    canonical: '/pages/web-development',
+  },
+  openGraph: {
+    title: 'Web Development Company India | Vedpragya',
+    description: 'Custom websites, web apps, SaaS platforms, and e-commerce solutions — enterprise-grade web development from India. 500+ projects delivered.',
+    url: 'https://vedpragya.com/pages/web-development',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Web Development Company India | Vedpragya',
+    description: 'Custom websites, web apps, SaaS platforms, and e-commerce — 500+ projects delivered from India.',
+  },
+};
+
+const faqQuestions = [
+  {
+    question: "What services does your web development agency offer?",
+    answer: "We offer a comprehensive range of web development services including custom website design, e-commerce development, web application development, CMS implementation, responsive design, UI/UX design, website maintenance, and performance optimization.",
+  },
+  {
+    question: "How long does it typically take to complete a website project?",
+    answer: "Project timelines vary depending on complexity and scope. A simple website might take 1–2 weeks, while more complex projects with custom functionality can take 2–3 months. During our initial consultation, we'll provide a more accurate timeline based on your specific requirements.",
+  },
+  {
+    question: "What is your pricing structure for web development projects?",
+    answer: "Our pricing is project-based and depends on the complexity, features, and timeline. We provide detailed quotes after understanding your requirements, typically with a deposit to begin work and milestone payments throughout the project.",
+  },
+  {
+    question: "Do you provide ongoing support after the website is launched?",
+    answer: "Yes, we offer various maintenance and support packages to keep your website secure, updated, and performing optimally — including regular updates, security monitoring, content updates, performance optimisation, and technical support.",
+  },
+];
+
 function WebDevelopmentPage() {
   return (
     <>
+      <FAQStructuredData questions={faqQuestions} />
+
       {/* Hero */}
       <SectionErrorBoundary name="Hero">
         <WDHero />

--- a/app/pages/web-development/page.tsx
+++ b/app/pages/web-development/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { buildPageMetadata } from '@/app/lib/seo/metadata';
 import React from "react";
 import { SectionErrorBoundary } from "@/app/components/common/SectionErrorBoundary";
 import { RelatedBlogPosts } from "@/app/components/RelatedBlogPosts";
@@ -14,25 +15,22 @@ import { FAQSection as WDFAQ } from "@/app/pages/website-development/_components
 import { AnimatedBannerCta as WDBannerCta } from "@/app/pages/website-development/_components/animated-banner-cta";
 import { ContactSection as WDContact } from "@/app/pages/website-development/_components/contact-section";
 
-export const metadata: Metadata = {
+export const metadata: Metadata = buildPageMetadata({
   title: 'Web Development Company India | Custom Websites & Web Apps — Vedpragya',
   description: 'Vedpragya is a web development company in India specialising in Next.js, React, Node.js, SaaS apps, e-commerce, and enterprise web solutions. 500+ projects delivered. Free consultation in 24 h.',
-  keywords: 'web development company india, web development services, hire web developer india, next.js development, react development, node.js development, custom web app development, saas development india, web development agency',
-  alternates: {
-    canonical: '/pages/web-development',
-  },
-  openGraph: {
-    title: 'Web Development Company India | Vedpragya',
-    description: 'Custom websites, web apps, SaaS platforms, and e-commerce solutions — enterprise-grade web development from India. 500+ projects delivered.',
-    url: 'https://vedpragya.com/pages/web-development',
-    type: 'website',
-  },
-  twitter: {
-    card: 'summary_large_image',
-    title: 'Web Development Company India | Vedpragya',
-    description: 'Custom websites, web apps, SaaS platforms, and e-commerce — 500+ projects delivered from India.',
-  },
-};
+  path: '/pages/web-development',
+  keywords: [
+    'web development company india',
+    'web development services',
+    'hire web developer india',
+    'next.js development',
+    'react development',
+    'node.js development',
+    'custom web app development',
+    'saas development india',
+    'web development agency',
+  ],
+});
 
 const faqQuestions = [
   {


### PR DESCRIPTION
## Summary

- **`/pages/web-development`** — adds keyword-optimised `metadata` export targeting "web development company india" and related high-intent queries. Previously this page served the root layout's generic homepage title/description to Google, causing duplicate SERP snippets. Also adds `FAQStructuredData` JSON-LD (4 Q&As mirroring the existing FAQ section) to enable featured-snippet eligibility.
- **`/pages/about`** — adds brand + entity metadata with canonical `/pages/about`. Previously fell back to root layout metadata, so Google showed homepage copy for the About page.

## Why this matters

Both pages had **zero custom metadata** — Google was indexing them with identical title/description strings from the root layout. For a site targeting competitive queries like "web development company india," having the primary service page share a title with the homepage tanks click-through rate and confuses Google's entity understanding.

## Test plan

- [ ] `next build` completes without type errors
- [ ] Visit `/pages/web-development` → `<title>` is "Web Development Company India | Custom Websites & Web Apps — Vedpragya"
- [ ] Visit `/pages/about` → `<title>` is "About Vedpragya | Engineering-First Software Agency — India"
- [ ] View page source on `/pages/web-development` → confirm `application/ld+json` FAQPage schema block is present
- [ ] Validate JSON-LD via Google Rich Results Test

https://claude.ai/code/session_01XDsfiVsV9ej2ctZqJRyfyy

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDsfiVsV9ej2ctZqJRyfyy)_