### PR TITLE
fix: dynamic OG images for blog posts + sitemap Mumbai date

### DIFF
--- a/app/pages/blog/[slug]/layout.tsx
+++ b/app/pages/blog/[slug]/layout.tsx
@@ -60,7 +60,7 @@ export async function generateMetadata({ params }: BlogSlugMetadataParams): Prom
     if (post) {
       const title = (dbPost as { title?: string } | null)?.title ?? (post as { title?: string }).title ?? normalizedSlug;
       const excerpt = (dbPost as { excerpt?: string } | null)?.excerpt ?? (post as { excerpt?: string }).excerpt ?? '';
-      const image = (dbPost as { image?: string | null } | null)?.image ?? (post as { image?: string }).image ?? '/logo.png';
+      const image = (dbPost as { image?: string | null } | null)?.image ?? (post as { image?: string }).image ?? '/og-default.jpg';
       const tags = (post as { tags?: string[] }).tags ?? [];
       const category = (post as { category?: string }).category ?? '';
       console.log('[SEO] Blog slug metadata generated', {
@@ -79,7 +79,7 @@ export async function generateMetadata({ params }: BlogSlugMetadataParams): Prom
           'software development insights',
           'digital growth insights',
         ].filter(Boolean) as string[],
-        imagePath: image || '/logo.png',
+        imagePath: image || '/og-default.jpg',
         ogType: 'article',
       });
     }
@@ -118,7 +118,7 @@ export default async function BlogSlugLayout({ children, params }: BlogSlugLayou
     if (post) {
       articleData = {
         headline: post.title,
-        image: post.image ? toAbsoluteSeoUrl(post.image) : `${SEO_SITE_URL}/logo.png`,
+        image: toAbsoluteSeoUrl(`/pages/blog/${normalizedSlug}/opengraph-image`),
         datePublished: new Date(post.publishedAt).toISOString(),
         dateModified: new Date(post.updatedAt || post.publishedAt).toISOString(),
         description: post.excerpt || '',

--- a/app/pages/blog/[slug]/opengraph-image.tsx
+++ b/app/pages/blog/[slug]/opengraph-image.tsx
@@ -1,0 +1,96 @@
+import { ImageResponse } from 'next/og';
+import { getBlogPost } from '@/app/lib/blog';
+
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+export default async function OGImage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const post = await getBlogPost(slug).catch(() => null);
+
+  const title = post?.title ?? 'Vedpragya Blog';
+  const category = (post?.category ?? 'web-development').replace(/-/g, ' ');
+  const readTime = post?.readTime ?? 8;
+  const fontSize = title.length > 70 ? 40 : title.length > 50 ? 48 : 56;
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          background: 'linear-gradient(135deg, #0a0f1e 0%, #0d2340 55%, #0a0f1e 100%)',
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          padding: '56px 72px',
+          fontFamily: 'sans-serif',
+        }}
+      >
+        {/* Top bar */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
+          <div
+            style={{
+              background: '#2563eb',
+              color: '#fff',
+              padding: '6px 18px',
+              borderRadius: '100px',
+              fontSize: '16px',
+              fontWeight: 700,
+              textTransform: 'capitalize',
+              letterSpacing: '0.04em',
+            }}
+          >
+            {category}
+          </div>
+          <div style={{ color: '#64748b', fontSize: '16px' }}>{readTime} min read</div>
+        </div>
+
+        {/* Title */}
+        <div
+          style={{
+            color: '#f1f5f9',
+            fontSize: `${fontSize}px`,
+            fontWeight: 800,
+            lineHeight: 1.22,
+            maxWidth: '1000px',
+            letterSpacing: '-0.02em',
+          }}
+        >
+          {title}
+        </div>
+
+        {/* Footer */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            width: '100%',
+          }}
+        >
+          <div style={{ color: '#94a3b8', fontSize: '20px', fontWeight: 600 }}>
+            vedpragya.com
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '8px',
+              color: '#3b82f6',
+              fontSize: '18px',
+              fontWeight: 600,
+            }}
+          >
+            Web Dev · AI · Shopify · Google Ads · India
+          </div>
+        </div>
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -72,6 +72,7 @@ const ROUTE_LAST_MODIFIED_MAP: Record<string, Date> = {
   '/pages/web-development-pune': new Date('2026-04-29T00:00:00.000Z'),
   '/pages/web-development-hyderabad': new Date('2026-04-29T00:00:00.000Z'),
   '/pages/web-development-noida': new Date('2026-04-29T00:00:00.000Z'),
+  '/pages/web-development-mumbai': new Date('2026-05-07T00:00:00.000Z'),
   '/pages/nodejs-development': new Date('2026-04-14T00:00:00.000Z'),
 
   // Legal pages — stable; use a fixed baseline date to avoid false freshness signals


### PR DESCRIPTION
## Summary

- **Dynamic OG image route** (`app/pages/blog/[slug]/opengraph-image.tsx`): generates a branded 1200×630 PNG per post via Next.js `ImageResponse` — title, category badge, read-time, site URL. Fixes broken `og:image` meta tags and `ArticleStructuredData` image URLs across all 26 blog posts (previously pointing to `/images/blog/*.jpg` which don't exist → 404s on every crawl).
- **Blog slug layout fix**: `ArticleStructuredData.image` now uses the live dynamic `/opengraph-image` URL; metadata fallback changed from `/logo.png` → `/og-default.jpg` (which actually exists in `public/`).
- **Sitemap**: added `web-development-mumbai` to `ROUTE_LAST_MODIFIED_MAP` with today's date — it was the only city page missing an explicit date, preventing Googlebot from prioritizing its re-crawl.

## Test plan

- [ ] `GET /pages/blog/how-to-hire-web-development-company-india/opengraph-image` returns a 1200×630 PNG with the post title
- [ ] View-source on any blog post confirms `og:image` points to the new `/opengraph-image` path, not `/images/blog/`
- [ ] `ArticleStructuredData` JSON-LD `image` field resolves (no 404) for any blog post
- [ ] `/sitemap.xml` lists `web-development-mumbai` with `lastmod` 2026-05-07

https://claude.ai/code/session_019Xu4YojE9zX8kBLbo2Eenh

---
_Generated by [Claude Code](https://claude.ai/code/session_019Xu4YojE9zX8kBLbo2Eenh)_