### PR TITLE
SEO: Add metadata exports to 38 service and landing pages

### DIFF
--- a/app/pages/ai-chatbot-development/page.tsx
+++ b/app/pages/ai-chatbot-development/page.tsx
@@ -45,6 +45,23 @@ import { FinalCTASection } from './_components/final-cta-section';
 import { MobileFloatingCTA } from './_components/mobile-floating-cta';
 import { ScrollToTop } from './_components/scroll-to-top';
 import { SectionErrorBoundary } from './_components/section-error-boundary';
+import type { Metadata } from 'next';
+import { buildPageMetadata } from '@/app/lib/seo/metadata';
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'AI Chatbot Development India | GPT-4, Claude & Gemini Bots — Vedpragya',
+  description: 'Custom AI chatbot development for Indian businesses. GPT-4, Claude, Gemini. WhatsApp, web, and API integrations. Sales bots, support bots, voice agents. Starting ₹49K. Free demo.',
+  path: '/pages/ai-chatbot-development',
+  keywords: [
+    'ai chatbot development india',
+    'custom ai chatbot india',
+    'gpt chatbot development india',
+    'ai chatbot company india',
+    'whatsapp ai bot india',
+    'chatbot development services',
+    'llm chatbot india',
+  ],
+});
 
 export default function AIChatbotDevelopmentPage() {
   return (

--- a/app/pages/ai-voice-agents/page.tsx
+++ b/app/pages/ai-voice-agents/page.tsx
@@ -57,6 +57,24 @@ import { SectionErrorBoundary } from './_components/section-error-boundary';
  * - Indian market focus (INR pricing, regional languages)
  * - Technical authority establishment
  */
+import type { Metadata } from 'next';
+import { buildPageMetadata } from '@/app/lib/seo/metadata';
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'AI Voice Agents Development India | Conversational AI — Vedpragya',
+  description: 'Build AI voice agents for sales, support, and scheduling. Powered by LLMs with natural Hindi and English speech. Reduce call centre costs by 60%. Free demo.',
+  path: '/pages/ai-voice-agents',
+  keywords: [
+    'ai voice agent development india',
+    'conversational ai india',
+    'voice ai bot india',
+    'ai phone agent india',
+    'voice chatbot development india',
+    'llm voice agent',
+    'ai call centre india',
+  ],
+});
+
 export default function AIVoiceAgentsPage() {
   return (
     <main className="min-h-screen bg-white dark:bg-gray-900">

--- a/app/pages/b2b-lead-generation-ads/page.tsx
+++ b/app/pages/b2b-lead-generation-ads/page.tsx
@@ -11,6 +11,23 @@ import { FAQSection } from './_components/faq-section';
 import { FinalCTASection } from './_components/final-cta-section';
 import { MobileFloatingCTA } from './_components/mobile-floating-cta';
 import { ScrollToTop } from './_components/scroll-to-top';
+import type { Metadata } from 'next';
+import { buildPageMetadata } from '@/app/lib/seo/metadata';
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'B2B Lead Generation Ads India | Google Ads for B2B — Vedpragya',
+  description: 'Google Ads campaigns built specifically for B2B lead generation in India. Target decision-makers, generate quality MQLs, and track cost-per-lead. Free strategy call.',
+  path: '/pages/b2b-lead-generation-ads',
+  keywords: [
+    'b2b lead generation ads india',
+    'b2b google ads india',
+    'b2b ppc india',
+    'lead generation ads india',
+    'b2b digital marketing india',
+    'google ads b2b india',
+    'b2b paid search india',
+  ],
+});
 
 export default function B2BLeadGenerationAdsPage() {
   return (

--- a/app/pages/business-website/page.tsx
+++ b/app/pages/business-website/page.tsx
@@ -33,6 +33,23 @@ import { FinalCTASection } from './_components/final-cta-section';
 import { MobileFloatingCTA } from './_components/mobile-floating-cta';
 import { ScrollToTop } from './_components/scroll-to-top';
 import { SectionErrorBoundary } from './_components/section-error-boundary';
+import type { Metadata } from 'next';
+import { buildPageMetadata } from '@/app/lib/seo/metadata';
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Business Website Development India | Professional Web Design — Vedpragya',
+  description: 'Professional business website development for Indian companies. Responsive design, fast loading, WhatsApp integration, and lead capture. Starting ₹9,999. Delivered in 7 days.',
+  path: '/pages/business-website',
+  keywords: [
+    'business website development india',
+    'professional website design india',
+    'company website india',
+    'small business website india',
+    'business website designer india',
+    'website for business india',
+    'corporate website india',
+  ],
+});
 
 export default function BusinessWebsitePage() {
   return (

--- a/app/pages/crm/page.tsx
+++ b/app/pages/crm/page.tsx
@@ -47,6 +47,23 @@ import { FinalCTASection } from './_components/final-cta-section';
 import { SectionErrorBoundary } from './_components/section-error-boundary';
 import { ScrollToTop } from './_components/scroll-to-top';
 import { MobileFloatingCTA } from './_components/mobile-floating-cta';
+import type { Metadata } from 'next';
+import { buildPageMetadata } from '@/app/lib/seo/metadata';
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'EnterpriseHero CRM — Self-Hosted CRM for Indian Businesses | Vedpragya',
+  description: 'A self-hosted, open-core CRM built for Indian B2B teams. Lead pipeline, sales automation, WhatsApp sync, and custom workflows. One-time setup. Your data, your server.',
+  path: '/pages/crm',
+  keywords: [
+    'self hosted crm india',
+    'crm software india',
+    'open source crm india',
+    'b2b crm india',
+    'sales crm india',
+    'custom crm development india',
+    'lead management software india',
+  ],
+});
 
 export default function CRMPage() {
   return (

--- a/app/pages/ecommerce-google-ads-optimization/page.tsx
+++ b/app/pages/ecommerce-google-ads-optimization/page.tsx
@@ -11,6 +11,23 @@ import { FAQSection } from './_components/faq-section';
 import { FinalCTASection } from './_components/final-cta-section';
 import { MobileFloatingCTA } from './_components/mobile-floating-cta';
 import { ScrollToTop } from './_components/scroll-to-top';
+import type { Metadata } from 'next';
+import { buildPageMetadata } from '@/app/lib/seo/metadata';
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'E-Commerce Google Ads Optimization India | Shopping & PMax — Vedpragya',
+  description: 'Google Shopping, Performance Max, and Dynamic Search Ads for Indian e-commerce. Lower ACOS, higher ROAS. Shopify, WooCommerce, custom stores. Free account audit.',
+  path: '/pages/ecommerce-google-ads-optimization',
+  keywords: [
+    'ecommerce google ads india',
+    'google shopping ads india',
+    'ecommerce ppc india',
+    'shopify google ads india',
+    'roas optimization india',
+    'performance max ecommerce india',
+    'google ads for online store india',
+  ],
+});
 
 export default function EcommerceGoogleAdsOptimizationPage() {
   return (

--- a/app/pages/enterprise-google-ads-management/page.tsx
+++ b/app/pages/enterprise-google-ads-management/page.tsx
@@ -28,6 +28,22 @@ import { SectionErrorBoundary } from './_components/section-error-boundary';
 // Shared Components
 import { ServiceNavigation } from '@/app/components/GoogleAdsEcosystem/ServiceNavigation';
 import { ROICalculator } from '@/app/components/GoogleAdsEcosystem/ROICalculator';
+import type { Metadata } from 'next';
+import { buildPageMetadata } from '@/app/lib/seo/metadata';
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Enterprise Google Ads Management India | High-Spend PPC Agency — Vedpragya',
+  description: 'Dedicated Google Ads management for enterprise accounts spending ₹5L+ per month. Strategic media buying, custom attribution, and executive reporting. Talk to a strategist today.',
+  path: '/pages/enterprise-google-ads-management',
+  keywords: [
+    'enterprise google ads management india',
+    'enterprise ppc agency india',
+    'large account google ads india',
+    'google ads for enterprise india',
+    'high spend ppc management india',
+    'enterprise paid search india',
+  ],
+});
 
 export default function EnterpriseGoogleAdsManagementPage() {
   return (

--- a/app/pages/google-ads-audit-strategy/page.tsx
+++ b/app/pages/google-ads-audit-strategy/page.tsx
@@ -11,6 +11,23 @@ import { FAQSection } from './_components/faq-section';
 import { FinalCTASection } from './_components/final-cta-section';
 import { MobileFloatingCTA } from './_components/mobile-floating-cta';
 import { ScrollToTop } from './_components/scroll-to-top';
+import type { Metadata } from 'next';
+import { buildPageMetadata } from '@/app/lib/seo/metadata';
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Google Ads Audit & Strategy India | Free PPC Account Review — Vedpragya',
+  description: 'Free Google Ads audit for Indian businesses. We identify wasted spend, missed opportunities, and quality score issues. Data-driven strategy session included. Book now.',
+  path: '/pages/google-ads-audit-strategy',
+  keywords: [
+    'google ads audit india',
+    'ppc audit india',
+    'google ads strategy india',
+    'google ads account review india',
+    'adwords audit india',
+    'google ads consultant india',
+    'ppc strategy india',
+  ],
+});
 
 export default function GoogleAdsAuditStrategyPage() {
   return (

--- a/app/pages/google-ads-ecosystem/page.tsx
+++ b/app/pages/google-ads-ecosystem/page.tsx
@@ -21,6 +21,23 @@ import { SectionErrorBoundary } from './_components/section-error-boundary';
 
 // Interactive client sections (filters, calculator)
 import { EcosystemInteractive } from './_components/ecosystem-interactive';
+import type { Metadata } from 'next';
+import { buildPageMetadata } from '@/app/lib/seo/metadata';
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Google Ads Full Ecosystem India | Search, Shopping & YouTube — Vedpragya',
+  description: 'Complete Google Ads management across Search, Shopping, Display, Performance Max, and YouTube for Indian businesses. One agency, every channel, maximum ROI.',
+  path: '/pages/google-ads-ecosystem',
+  keywords: [
+    'google ads ecosystem india',
+    'full funnel google ads india',
+    'google ads agency india',
+    'google search ads india',
+    'google shopping ads india',
+    'google display ads india',
+    'performance marketing india',
+  ],
+});
 
 export default function GoogleAdsEcosystemPage() {
   return (

--- a/app/pages/google-ads-management/page.tsx
+++ b/app/pages/google-ads-management/page.tsx
@@ -34,6 +34,23 @@ import { FinalCTASection } from './_components/final-cta-section';
 import { MobileFloatingCTA } from './_components/mobile-floating-cta';
 import { ScrollToTop } from './_components/scroll-to-top';
 import { SectionErrorBoundary } from './_components/section-error-boundary';
+import type { Metadata } from 'next';
+import { buildPageMetadata } from '@/app/lib/seo/metadata';
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Google Ads Management Agency India | PPC Experts — Vedpragya',
+  description: 'Certified Google Ads management for Indian businesses. Search, Display, Shopping, and Performance Max campaigns. ROI-focused. ₹25K–₹50K+ retainers. Free audit call.',
+  path: '/pages/google-ads-management',
+  keywords: [
+    'google ads management india',
+    'google ads agency india',
+    'ppc management india',
+    'google ads expert india',
+    'google ads consultant india',
+    'paid ads agency india',
+    'google ads management services',
+  ],
+});
 
 export default function GoogleAdsManagementPage() {
   return (

--- a/app/pages/healthcare-software-development/page.tsx
+++ b/app/pages/healthcare-software-development/page.tsx
@@ -48,6 +48,23 @@ import { FinalCTASection } from './_components/final-cta-section';
 import { MobileFloatingCTA } from './_components/mobile-floating-cta';
 import { ScrollToTop } from './_components/scroll-to-top';
 import { SectionErrorBoundary } from './_components/section-error-boundary';
+import type { Metadata } from 'next';
+import { buildPageMetadata } from '@/app/lib/seo/metadata';
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Healthcare Software Development India | HIPAA-Ready Systems — Vedpragya',
+  description: 'Custom healthcare software development for Indian clinics, hospitals, and healthtech startups. EMR, telemedicine, HL7 FHIR APIs, and patient management systems. HIPAA-ready. Free consultation.',
+  path: '/pages/healthcare-software-development',
+  keywords: [
+    'healthcare software development india',
+    'health tech software company india',
+    'hospital management software india',
+    'emr software development india',
+    'telemedicine app development india',
+    'healthcare app development',
+    'medical software india',
+  ],
+});
 
 export default function HealthcareSoftwareDevelopmentPage() {
   return (

--- a/app/pages/landing-page-optimization/page.tsx
+++ b/app/pages/landing-page-optimization/page.tsx
@@ -11,6 +11,23 @@ import { FAQSection } from './_components/faq-section';
 import { FinalCTASection } from './_components/final-cta-section';
 import { MobileFloatingCTA } from './_components/mobile-floating-cta';
 import { ScrollToTop } from './_components/scroll-to-top';
+import type { Metadata } from 'next';
+import { buildPageMetadata } from '@/app/lib/seo/metadata';
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Landing Page Optimization India | CRO for Google Ads — Vedpragya',
+  description: 'Conversion rate optimization and landing page design for Google Ads campaigns in India. A/B testing, heatmaps, and copy that converts. Increase leads without increasing ad spend.',
+  path: '/pages/landing-page-optimization',
+  keywords: [
+    'landing page optimization india',
+    'cro india',
+    'conversion rate optimization india',
+    'landing page design india',
+    'google ads landing page india',
+    'ab testing india',
+    'ppc landing page india',
+  ],
+});
 
 export default function LandingPageOptimizationPage() {
   return (

--- a/app/pages/local-business-google-ads/page.tsx
+++ b/app/pages/local-business-google-ads/page.tsx
@@ -11,6 +11,23 @@ import { FAQSection } from './_components/faq-section';
 import { FinalCTASection } from './_components/final-cta-section';
 import { MobileFloatingCTA } from './_components/mobile-floating-cta';
 import { ScrollToTop } from './_components/scroll-to-top';
+import type { Metadata } from 'next';
+import { buildPageMetadata } from '@/app/lib/seo/metadata';
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Google Ads for Local Business India | Location-Targeted PPC — Vedpragya',
+  description: 'Google Ads management for local businesses across India. City-targeted search campaigns, Google Maps ads, and call extensions. Generate calls and walk-ins. Free setup audit.',
+  path: '/pages/local-business-google-ads',
+  keywords: [
+    'google ads local business india',
+    'local ppc india',
+    'google maps ads india',
+    'local search ads india',
+    'google ads for small business india',
+    'local google ads agency india',
+    'city targeted google ads india',
+  ],
+});
 
 export default function LocalBusinessGoogleAdsPage() {
   return (

--- a/app/pages/next-js-development/page.tsx
+++ b/app/pages/next-js-development/page.tsx
@@ -35,6 +35,23 @@ import { MobileFloatingCTA } from './_components/mobile-floating-cta';
 import { ScrollToTop } from './_components/scroll-to-top';
 import { SectionErrorBoundary } from './_components/section-error-boundary';
 import { RelatedServicesStrip } from '@/app/components/RelatedServicesStrip';
+import type { Metadata } from 'next';
+import { buildPageMetadata } from '@/app/lib/seo/metadata';
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Next.js Development Company India | App Router Experts — Vedpragya',
+  description: 'Hire Next.js developers in India. We build blazing-fast, SEO-optimised Next.js 15 apps with App Router, TypeScript, and Tailwind. From MVPs to enterprise platforms. Free consultation.',
+  path: '/pages/next-js-development',
+  keywords: [
+    'next.js development company india',
+    'hire next.js developer india',
+    'nextjs development services india',
+    'next.js 15 development',
+    'next.js app router development',
+    'next.js agency india',
+    'react next.js developer',
+  ],
+});
 
 export default function NextJsDevelopmentPage() {
   return (

--- a/app/pages/nodejs-development/page.tsx
+++ b/app/pages/nodejs-development/page.tsx
@@ -1,7 +1,24 @@
 import Link from 'next/link';
 import type { ReactElement } from 'react';
+import type { Metadata } from 'next';
 import { RelatedBlogPosts } from '@/app/components/RelatedBlogPosts';
 import { RelatedServicesStrip } from '@/app/components/RelatedServicesStrip';
+import { buildPageMetadata } from '@/app/lib/seo/metadata';
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Node.js Development Company India | Hire Node.js Developers — Vedpragya',
+  description: 'Expert Node.js development company in India. We build scalable APIs, real-time apps, and microservices with Node.js, Express, and NestJS. Hire Node.js developers. Free consultation.',
+  path: '/pages/nodejs-development',
+  keywords: [
+    'node.js development company india',
+    'hire node.js developer india',
+    'nodejs development services india',
+    'node.js backend development',
+    'express.js development india',
+    'nestjs development india',
+    'api development india',
+  ],
+});
 
 /**
  * Node.js Development service landing page.

--- a/app/pages/nse-mcx-live-market-data/page.tsx
+++ b/app/pages/nse-mcx-live-market-data/page.tsx
@@ -58,6 +58,23 @@ import { FinalCTASection } from './_components/final-cta-section';
 import { MobileFloatingCTA } from './_components/mobile-floating-cta';
 import { ScrollToTop } from './_components/scroll-to-top';
 import { SectionErrorBoundary } from './_components/section-error-boundary';
+import type { Metadata } from 'next';
+import { buildPageMetadata } from '@/app/lib/seo/metadata';
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'NSE MCX Live Market Data API India | Real-Time Feed Integration — Vedpragya',
+  description: 'Real-time NSE, MCX, and BSE market data API integration for trading apps, dashboards, and brokers. WebSocket feeds, tick data, historical OHLCV. Custom development. Free scoping call.',
+  path: '/pages/nse-mcx-live-market-data',
+  keywords: [
+    'nse live market data api india',
+    'mcx live data api india',
+    'stock market data api india',
+    'real-time market data feed india',
+    'nse api integration india',
+    'trading data api india',
+    'stock tick data india',
+  ],
+});
 
 export default function NSEMCXLiveMarketDataPage() {
   return (

--- a/app/pages/performance-max-campaigns/page.tsx
+++ b/app/pages/performance-max-campaigns/page.tsx
@@ -11,6 +11,22 @@ import { FAQSection } from './_components/faq-section';
 import { FinalCTASection } from './_components/final-cta-section';
 import { MobileFloatingCTA } from './_components/mobile-floating-cta';
 import { ScrollToTop } from './_components/scroll-to-top';
+import type { Metadata } from 'next';
+import { buildPageMetadata } from '@/app/lib/seo/metadata';
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Performance Max Campaigns India | PMax Google Ads Management — Vedpragya',
+  description: 'Expert Performance Max (PMax) campaign management for Indian businesses. Asset group strategy, audience signals, and ROAS optimisation across Google channels. Free consultation.',
+  path: '/pages/performance-max-campaigns',
+  keywords: [
+    'performance max campaigns india',
+    'pmax google ads india',
+    'google performance max india',
+    'pmax management india',
+    'performance max agency india',
+    'google ads pmax india',
+  ],
+});
 
 export default function PerformanceMaxCampaignsPage() {
   return (

--- a/app/pages/portfolio/page.tsx
+++ b/app/pages/portfolio/page.tsx
@@ -1,5 +1,21 @@
 import Link from "next/link";
+import type { Metadata } from 'next';
+import { buildPageMetadata } from '@/app/lib/seo/metadata';
 import { BackgroundBeams } from "@/app/components/ui/background-beams";
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Portfolio | Web Dev, AI & SaaS Case Studies — Vedpragya',
+  description: 'See what Vedpragya has built: AI voice systems, headless Shopify migrations, fintech platforms, and SaaS products. Real outcomes, real clients across India, UAE, and the US.',
+  path: '/pages/portfolio',
+  keywords: [
+    'web development portfolio india',
+    'software agency portfolio india',
+    'case studies web development',
+    'next.js portfolio india',
+    'saas development examples india',
+    'vedpragya portfolio',
+  ],
+});
 import { Spotlight } from "@/app/components/ui/spotlight";
 import { MovingBorder } from "@/app/components/ui/moving-border";
 

--- a/app/pages/reactjs-development/page.tsx
+++ b/app/pages/reactjs-development/page.tsx
@@ -35,6 +35,23 @@ import { MobileFloatingCTA } from './_components/mobile-floating-cta';
 import { ScrollToTop } from './_components/scroll-to-top';
 import { SectionErrorBoundary } from './_components/section-error-boundary';
 import { RelatedServicesStrip } from '@/app/components/RelatedServicesStrip';
+import type { Metadata } from 'next';
+import { buildPageMetadata } from '@/app/lib/seo/metadata';
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'ReactJS Development Company India | Hire React Developers — Vedpragya',
+  description: 'Top ReactJS development company in India. Build fast, scalable web apps with React 19, TypeScript, and modern state management. Startups to enterprise. Free consultation.',
+  path: '/pages/reactjs-development',
+  keywords: [
+    'reactjs development company india',
+    'hire react developer india',
+    'react js development services india',
+    'react app development india',
+    'react developer india',
+    'react 19 development',
+    'frontend development india',
+  ],
+});
 
 export default function ReactJSDevelopmentPage() {
   return (

--- a/app/pages/resources/page.tsx
+++ b/app/pages/resources/page.tsx
@@ -1,5 +1,21 @@
 import { ResourcesClient } from './_components/resources-client';
 import { Resource } from '../../types/blog';
+import type { Metadata } from 'next';
+import { buildPageMetadata } from '@/app/lib/seo/metadata';
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Free Web Dev & AI Resources | Guides & Tools — Vedpragya',
+  description: 'Free resources for founders and engineering teams: web development guides, AI integration tutorials, Shopify tips, and Google Ads checklists. Curated by Vedpragya.',
+  path: '/pages/resources',
+  keywords: [
+    'web development resources india',
+    'free developer guides india',
+    'nextjs tutorials india',
+    'ai development resources',
+    'shopify development guides',
+    'google ads resources india',
+  ],
+});
 
 async function getInitialResources(): Promise<Resource[]> {
   try {

--- a/app/pages/saas-website-design/page.tsx
+++ b/app/pages/saas-website-design/page.tsx
@@ -5,6 +5,23 @@ import { TechStackSection } from './_components/tech-stack-section';
 import { LeadFormSection } from './_components/lead-form-section';
 import { FAQSection } from './_components/faq-section';
 import { FinalCtaSection } from './_components/final-cta-section';
+import type { Metadata } from 'next';
+import { buildPageMetadata } from '@/app/lib/seo/metadata';
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'SaaS Website Design India | Next.js UI/UX for Startups — Vedpragya',
+  description: 'High-converting SaaS landing pages and marketing sites for Indian startups. Next.js, Framer Motion, and type-forward design. Onboarding flows, pricing pages, and demo CTAs. Free brief.',
+  path: '/pages/saas-website-design',
+  keywords: [
+    'saas website design india',
+    'saas landing page design india',
+    'saas ui ux design india',
+    'saas marketing website india',
+    'next.js saas website',
+    'saas website agency india',
+    'framer developer india',
+  ],
+});
 
 export default function SaasWebsiteDesignPage() {
   return (

--- a/app/pages/seo-audit/page.tsx
+++ b/app/pages/seo-audit/page.tsx
@@ -27,6 +27,23 @@ import { TestimonialsSection } from './_components/testimonials-section';
 import { FAQSection } from './_components/faq-section';
 import { FinalCTASection } from './_components/final-cta-section';
 import { SectionErrorBoundary } from '../business-website/_components/section-error-boundary';
+import type { Metadata } from 'next';
+import { buildPageMetadata } from '@/app/lib/seo/metadata';
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Free SEO Audit India | Website Technical SEO Analysis — Vedpragya',
+  description: 'Get a free technical SEO audit for your website. We check Core Web Vitals, indexation, schema, on-page signals, and backlink gaps. Instant report. No credit card required.',
+  path: '/pages/seo-audit',
+  keywords: [
+    'free seo audit india',
+    'website seo audit india',
+    'technical seo audit india',
+    'seo analysis india',
+    'core web vitals audit',
+    'seo agency india',
+    'website audit india',
+  ],
+});
 
 export default function SEOAuditPage() {
   return (

--- a/app/pages/services/page.tsx
+++ b/app/pages/services/page.tsx
@@ -1,5 +1,22 @@
 import Link from "next/link";
+import type { Metadata } from 'next';
+import { buildPageMetadata } from '@/app/lib/seo/metadata';
 import { BackgroundBeams } from "@/app/components/ui/background-beams";
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Our Services | Web Dev, AI, Google Ads & Shopify — Vedpragya',
+  description: 'Vedpragya offers web development, AI chatbots, Google Ads management, Shopify development, and ERP solutions for Indian businesses. End-to-end digital product studio.',
+  path: '/pages/services',
+  keywords: [
+    'web development services india',
+    'ai development services india',
+    'google ads services india',
+    'shopify services india',
+    'software development services india',
+    'digital agency services india',
+    'vedpragya services',
+  ],
+});
 import { Spotlight } from "@/app/components/ui/spotlight";
 import { MovingBorder } from "@/app/components/ui/moving-border";
 import { BentoGrid, BentoGridItem } from "@/app/components/ui/bento-grid";

--- a/app/pages/shopify-headless-migration/page.tsx
+++ b/app/pages/shopify-headless-migration/page.tsx
@@ -55,6 +55,23 @@ import { FinalCTASection } from './_components/final-cta-section';
 import { MobileFloatingCTA } from './_components/mobile-floating-cta';
 import { ScrollToTop } from './_components/scroll-to-top';
 import { SectionErrorBoundary } from '@/app/components/common/SectionErrorBoundary';
+import type { Metadata } from 'next';
+import { buildPageMetadata } from '@/app/lib/seo/metadata';
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Shopify Headless Migration to Next.js India | Hydrogen — Vedpragya',
+  description: 'Migrate your Shopify store to headless Next.js or Hydrogen for 3× faster page loads and full design freedom. Expert migration team in India. Free performance audit.',
+  path: '/pages/shopify-headless-migration',
+  keywords: [
+    'shopify headless migration india',
+    'shopify to next.js migration india',
+    'shopify hydrogen development india',
+    'headless commerce india',
+    'shopify headless agency india',
+    'shopify next.js india',
+    'headless shopify india',
+  ],
+});
 
 export default function ShopifyHeadlessMigrationPage() {
   return (

--- a/app/pages/shopify-product-page-customization/page.tsx
+++ b/app/pages/shopify-product-page-customization/page.tsx
@@ -48,6 +48,23 @@ import { FinalCTASection } from './_components/final-cta-section';
 import { MobileFloatingCTA } from './_components/mobile-floating-cta';
 import { ScrollToTop } from './_components/scroll-to-top';
 import { SectionErrorBoundary } from './_components/section-error-boundary';
+import type { Metadata } from 'next';
+import { buildPageMetadata } from '@/app/lib/seo/metadata';
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Shopify Product Page Customization India | CRO & Design — Vedpragya',
+  description: 'Custom Shopify product page design for higher conversions. Metafield sections, custom components, trust signals, and A/B tested layouts. Boost your add-to-cart rate. Free review.',
+  path: '/pages/shopify-product-page-customization',
+  keywords: [
+    'shopify product page customization india',
+    'shopify product page design india',
+    'shopify page builder india',
+    'shopify cro india',
+    'shopify theme customization india',
+    'shopify developer india',
+    'shopify conversion optimization india',
+  ],
+});
 
 export default function ShopifyProductPageCustomizationPage() {
   return (

--- a/app/pages/shopify-store-setup/page.tsx
+++ b/app/pages/shopify-store-setup/page.tsx
@@ -42,6 +42,24 @@ import ResultsSection from '@/app/components/shopify/ResultsSection';
 import FinalCTASection from '@/app/components/shopify/FinalCTASection';
 import ContactFormSection from '@/app/components/shopify/ContactFormSection';
 
+import type { Metadata } from 'next';
+import { buildPageMetadata } from '@/app/lib/seo/metadata';
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Shopify Store Setup India | E-Commerce Agency — Vedpragya',
+  description: 'Professional Shopify store setup for Indian businesses. Theme customisation, payment gateway integration (Razorpay, UPI), product catalogue, and launch. Starting ₹9,999. Free quote.',
+  path: '/pages/shopify-store-setup',
+  keywords: [
+    'shopify store setup india',
+    'shopify development india',
+    'shopify agency india',
+    'shopify store india',
+    'ecommerce store setup india',
+    'shopify developer india',
+    'shopify razorpay integration india',
+  ],
+});
+
 console.log('[ShopifyStorePage] Page component loaded');
 
 

--- a/app/pages/trading-software/page.tsx
+++ b/app/pages/trading-software/page.tsx
@@ -62,6 +62,24 @@ import { SectionErrorBoundary } from './_components/section-error-boundary';
  * - Technical authority establishment
  * - Premium, techy aesthetic with trading terminal vibes
  */
+import type { Metadata } from 'next';
+import { buildPageMetadata } from '@/app/lib/seo/metadata';
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Trading Software Development India | Algo & HFT Platforms — Vedpragya',
+  description: 'Custom trading software development — algo trading, HFT platforms, NSE/BSE broker tools, and market data dashboards. Built for speed, reliability, and SEBI compliance. Free scoping call.',
+  path: '/pages/trading-software',
+  keywords: [
+    'trading software development india',
+    'algo trading platform development india',
+    'hft trading software india',
+    'stock market software development',
+    'nse bse trading platform',
+    'broker software development india',
+    'fintech software india',
+  ],
+});
+
 export default function TradingSoftwarePage() {
   return (
     <main className="min-h-screen bg-gradient-to-b from-[#0A1628] via-[#0d1b2e] to-[#0A1628]">

--- a/app/pages/web-development-bangalore/page.tsx
+++ b/app/pages/web-development-bangalore/page.tsx
@@ -1,4 +1,21 @@
 import { CityLandingPage } from '@/app/components/CityLandingPage';
+import type { Metadata } from 'next';
+import { buildPageMetadata } from '@/app/lib/seo/metadata';
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Web Development Company Bangalore | SaaS & Startup Agency — Vedpragya',
+  description: 'Expert web development company for Bangalore startups and enterprises. Next.js, React, and TypeScript SaaS platforms, APIs, and engineering-grade web apps. Free consultation.',
+  path: '/pages/web-development-bangalore',
+  keywords: [
+    'web development company bangalore',
+    'website development bangalore',
+    'web developer bangalore',
+    'saas development bangalore',
+    'react developer bangalore',
+    'startup web development bangalore',
+    'software company bangalore',
+  ],
+});
 
 export default function BangaloreWebDevelopmentPage() {
   return (

--- a/app/pages/web-development-delhi/page.tsx
+++ b/app/pages/web-development-delhi/page.tsx
@@ -1,4 +1,21 @@
 import { CityLandingPage } from '@/app/components/CityLandingPage';
+import type { Metadata } from 'next';
+import { buildPageMetadata } from '@/app/lib/seo/metadata';
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Web Development Company Delhi NCR | Next.js & React Agency — Vedpragya',
+  description: 'Top web development company in Delhi NCR. Custom websites, SaaS apps, and e-commerce for Delhi businesses. Next.js, React, Node.js. Haryana-registered. Free consultation.',
+  path: '/pages/web-development-delhi',
+  keywords: [
+    'web development company delhi',
+    'web development delhi ncr',
+    'website development delhi',
+    'web developer delhi',
+    'react developer delhi',
+    'nextjs developer delhi',
+    'software company delhi ncr',
+  ],
+});
 
 export default function DelhiWebDevelopmentPage() {
   return (

--- a/app/pages/web-development-gurgaon/page.tsx
+++ b/app/pages/web-development-gurgaon/page.tsx
@@ -1,4 +1,21 @@
 import { CityLandingPage } from '@/app/components/CityLandingPage';
+import type { Metadata } from 'next';
+import { buildPageMetadata } from '@/app/lib/seo/metadata';
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Web Development Company Gurgaon | Local Haryana Agency — Vedpragya',
+  description: 'Your local web development partner in Gurgaon. Haryana-registered agency building corporate websites, SaaS platforms, and enterprise web apps for Gurgaon businesses. Free quote.',
+  path: '/pages/web-development-gurgaon',
+  keywords: [
+    'web development company gurgaon',
+    'website development gurgaon',
+    'web developer gurgaon',
+    'software company gurgaon',
+    'it company gurgaon',
+    'web agency gurgaon',
+    'nextjs developer gurgaon',
+  ],
+});
 
 export default function GurgaonWebDevelopmentPage() {
   return (

--- a/app/pages/web-development-hyderabad/page.tsx
+++ b/app/pages/web-development-hyderabad/page.tsx
@@ -1,4 +1,21 @@
 import { CityLandingPage } from '@/app/components/CityLandingPage';
+import type { Metadata } from 'next';
+import { buildPageMetadata } from '@/app/lib/seo/metadata';
+
+export const metadata: Metadata = buildPageMetadata({
+  title: "Web Development Company Hyderabad | Pharma & SaaS Tech — Vedpragya",
+  description: "Web development for Hyderabad's pharma, healthtech, and SaaS industries. Next.js, TypeScript, and enterprise engineering. HIPAA-ready systems available. Free consultation.",
+  path: '/pages/web-development-hyderabad',
+  keywords: [
+    'web development company hyderabad',
+    'website development hyderabad',
+    'web developer hyderabad',
+    'software company hyderabad',
+    'saas development hyderabad',
+    'healthtech development hyderabad',
+    'it company hyderabad',
+  ],
+});
 
 export default function HyderabadWebDevelopmentPage() {
   return (

--- a/app/pages/web-development-mumbai/page.tsx
+++ b/app/pages/web-development-mumbai/page.tsx
@@ -36,6 +36,23 @@ import { MobileFloatingCTA } from './_components/mobile-floating-cta';
 import { ScrollToTop } from './_components/scroll-to-top';
 import { SectionErrorBoundary } from './_components/section-error-boundary';
 import { RelatedServicesStrip } from '@/app/components/RelatedServicesStrip';
+import type { Metadata } from 'next';
+import { buildPageMetadata } from '@/app/lib/seo/metadata';
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Web Development Company Mumbai | Custom Web Apps & SaaS — Vedpragya',
+  description: "Top web development company for Mumbai businesses. Custom websites, SaaS platforms, e-commerce, and fintech web apps. Next.js, React, Node.js. Free consultation.",
+  path: '/pages/web-development-mumbai',
+  keywords: [
+    'web development company mumbai',
+    'website development mumbai',
+    'web developer mumbai',
+    'software company mumbai',
+    'saas development mumbai',
+    'fintech development mumbai',
+    'react developer mumbai',
+  ],
+});
 
 export default function MumbaiWebDevelopmentPage() {
   return (

--- a/app/pages/web-development-noida/page.tsx
+++ b/app/pages/web-development-noida/page.tsx
@@ -1,4 +1,21 @@
 import { CityLandingPage } from '@/app/components/CityLandingPage';
+import type { Metadata } from 'next';
+import { buildPageMetadata } from '@/app/lib/seo/metadata';
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Web Development Company Noida | IT & Edtech Specialists — Vedpragya',
+  description: "Web development for Noida's IT services, BPO, and edtech companies. Custom Next.js apps, enterprise portals, and scalable APIs. Fully remote. Free consultation.",
+  path: '/pages/web-development-noida',
+  keywords: [
+    'web development company noida',
+    'website development noida',
+    'web developer noida',
+    'it company noida',
+    'software company noida',
+    'edtech development noida',
+    'react developer noida',
+  ],
+});
 
 export default function NoidaWebDevelopmentPage() {
   return (

--- a/app/pages/web-development-pune/page.tsx
+++ b/app/pages/web-development-pune/page.tsx
@@ -1,4 +1,21 @@
 import { CityLandingPage } from '@/app/components/CityLandingPage';
+import type { Metadata } from 'next';
+import { buildPageMetadata } from '@/app/lib/seo/metadata';
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Web Development Company Pune | SaaS & Enterprise Apps — Vedpragya',
+  description: "Custom web development for Pune's IT, manufacturing, and education sectors. SaaS platforms, enterprise web apps, and e-commerce built with Next.js and React. Free consultation.",
+  path: '/pages/web-development-pune',
+  keywords: [
+    'web development company pune',
+    'website development pune',
+    'web developer pune',
+    'saas development pune',
+    'it company pune',
+    'software development company pune',
+    'react developer pune',
+  ],
+});
 
 export default function PuneWebDevelopmentPage() {
   return (

--- a/app/pages/website-development/page.tsx
+++ b/app/pages/website-development/page.tsx
@@ -11,6 +11,23 @@ import { HeroParallax } from "@/app/components/ui/hero-parallax";
 import { StickyScroll } from "@/app/components/ui/sticky-scroll-reveal";
 import { Spotlight } from "@/app/components/ui/spotlight";
 import { RelatedServicesStrip } from "@/app/components/RelatedServicesStrip";
+import type { Metadata } from 'next';
+import { buildPageMetadata } from '@/app/lib/seo/metadata';
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Website Development Company India | Modern Web Solutions — Vedpragya',
+  description: 'Full-stack website development for Indian businesses and startups. Landing pages, e-commerce, SaaS apps, and enterprise portals. React, Next.js, Node.js. Free consultation.',
+  path: '/pages/website-development',
+  keywords: [
+    'website development company india',
+    'website development services india',
+    'hire website developer india',
+    'full stack website development india',
+    'website agency india',
+    'web design company india',
+    'website developer india',
+  ],
+});
 
 const products = [
   {

--- a/app/pages/website-services/page.tsx
+++ b/app/pages/website-services/page.tsx
@@ -1,5 +1,22 @@
 import React from "react";
+import type { Metadata } from 'next';
+import { buildPageMetadata } from '@/app/lib/seo/metadata';
 import { ServicesHero } from "./_components/services-hero-section";
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Website Services India | Web Design, Dev & Maintenance — Vedpragya',
+  description: 'End-to-end website services for Indian businesses. Design, development, hosting, maintenance, and SEO. One agency for everything. Fixed pricing, fast delivery.',
+  path: '/pages/website-services',
+  keywords: [
+    'website services india',
+    'web design services india',
+    'website maintenance india',
+    'website development services india',
+    'web agency india',
+    'website company india',
+    'web services india',
+  ],
+});
 import { ServicesList } from "./_components/services-list-section";
 import { ProcessSection } from "./_components/process-section";
 import { TechnologiesSection } from "./_components/technologies-section";

--- a/app/pages/whatsapp-business-api/page.tsx
+++ b/app/pages/whatsapp-business-api/page.tsx
@@ -52,6 +52,23 @@ import { FinalCTASection } from './_components/final-cta-section';
 import { MobileFloatingCTA } from './_components/mobile-floating-cta';
 import { ScrollToTop } from './_components/scroll-to-top';
 import { SectionErrorBoundary } from './_components/section-error-boundary';
+import type { Metadata } from 'next';
+import { buildPageMetadata } from '@/app/lib/seo/metadata';
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'WhatsApp Business API Integration India | Automation & Bots — Vedpragya',
+  description: 'Official WhatsApp Business API integration for Indian businesses. Automated notifications, AI chatbots, CRM sync, and bulk messaging. Starting ₹15K/month. Free demo.',
+  path: '/pages/whatsapp-business-api',
+  keywords: [
+    'whatsapp business api india',
+    'whatsapp api integration india',
+    'whatsapp chatbot india',
+    'whatsapp automation india',
+    'whatsapp business solution provider india',
+    'whatsapp crm integration',
+    'bulk whatsapp messaging india',
+  ],
+});
 
 export default function WhatsAppBusinessAPIPage() {
   return (

--- a/app/pages/youtube-advertising-management/page.tsx
+++ b/app/pages/youtube-advertising-management/page.tsx
@@ -11,6 +11,23 @@ import { FAQSection } from './_components/faq-section';
 import { FinalCTASection } from './_components/final-cta-section';
 import { MobileFloatingCTA } from './_components/mobile-floating-cta';
 import { ScrollToTop } from './_components/scroll-to-top';
+import type { Metadata } from 'next';
+import { buildPageMetadata } from '@/app/lib/seo/metadata';
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'YouTube Advertising Management India | Video Ads Agency — Vedpragya',
+  description: 'YouTube video ad campaigns for Indian brands. In-stream, bumper, and discovery ads. Creative strategy, targeting, and conversion tracking. Reach crores of viewers. Free brief.',
+  path: '/pages/youtube-advertising-management',
+  keywords: [
+    'youtube advertising india',
+    'youtube ads management india',
+    'youtube video ads india',
+    'youtube marketing agency india',
+    'youtube ads agency india',
+    'video advertising india',
+    'youtube campaign management india',
+  ],
+});
 
 export default function YouTubeAdvertisingManagementPage() {
   return (


### PR DESCRIPTION
## Summary

- **Root cause fixed**: 38 of 42 pages had no `export const metadata` — Google was indexing them with blank titles, no description, and no canonical tag. Zero keyword signal = zero ranking potential.
- Added `buildPageMetadata()` calls with targeted titles, descriptions, and keyword arrays to all affected pages: service pages, city landing pages, Google Ads ecosystem pages, Shopify pages, and navigational pages.
- Client-component pages (`contact/page.tsx`) already use the `layout.tsx` metadata pattern — no change needed there.

## Pages covered (38)

| Category | Pages |
|---|---|
| Web dev tech | next-js-development, reactjs-development, nodejs-development, website-development, website-services, business-website |
| AI / Automation | ai-chatbot-development, ai-voice-agents, whatsapp-business-api, crm |
| Specialty tech | healthcare-software-development, trading-software, nse-mcx-live-market-data, saas-website-design |
| Google Ads (10) | google-ads-management, ecosystem, audit-strategy, b2b-lead-gen, ecommerce, enterprise, landing-page-opt, local-business, performance-max, youtube |
| Shopify | shopify-store-setup, shopify-headless-migration, shopify-product-page-customization |
| City landing pages (7) | Delhi, Bangalore, Gurgaon, Pune, Hyderabad, Noida, Mumbai |
| Navigational | services, portfolio, resources, seo-audit |

## Test plan

- [ ] `next build` passes with no metadata-related errors
- [ ] `curl -s https://vedpragya.com/pages/google-ads-management | grep "<title>"` returns keyword-targeted title
- [ ] Google Search Console → URL Inspection on any previously blank-title page shows new title within 24–48 h after deploy

https://claude.ai/code/session_01FVp2JQA24QmYi453GyWZqA

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVp2JQA24QmYi453GyWZqA)_