### PR TITLE
fix(lead): queue IntegrationRetry on contact form Zoho failure

### DIFF
--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -103,20 +103,27 @@ export async function POST(request: NextRequest) {
       
       console.log(`[API/Contact] Synced to Zoho: ${zohoLeadId}`);
     } catch (zohoError: any) {
-      console.error('[API/Contact] Zoho sync failed:', zohoError.message);
-      // We don't fail the request, just log it. The lead is safe in our DB.
-      // Optionally queue for retry (simplified here compared to /api/lead)
+      console.error('[API/Contact] Zoho sync failed, queuing for retry:', zohoError.message);
       await prisma.lead.update({
         where: { id: lead.id },
         data: { status: 'failed' }
       });
-      
+      await prisma.integrationRetry.create({
+        data: {
+          type: 'zoho_lead',
+          payload: { leadId: lead.id },
+          attempts: 0,
+          status: 'queued',
+          nextRunAt: new Date(Date.now() + 60 * 1000),
+          lastError: String(zohoError?.message || zohoError),
+        },
+      });
       await prisma.integrationLog.create({
         data: {
           type: 'lead_submit',
           provider: 'zoho',
           level: 'error',
-          message: `Zoho submission failed for contact form lead ${lead.id}`,
+          message: `Zoho submission failed for contact form lead ${lead.id}; queued for retry`,
           error: String(zohoError?.message || zohoError),
           correlationId,
         },


### PR DESCRIPTION
## Summary

- `/api/contact` was silently abandoning Zoho-failed leads at `status: 'failed'` with no retry path
- Added `IntegrationRetry` record creation on Zoho failure, matching the behavior already in `/api/lead`
- Contact page leads now flow through the same retry worker as all other 17 landing page forms

## Test plan

- [ ] Submit contact form with Zoho credentials revoked → confirm `IntegrationRetry` row created in DB with `type: 'zoho_lead'` and `status: 'queued'`
- [ ] Restore Zoho credentials → confirm retry worker picks up and pushes the lead
- [ ] Normal contact form submit (Zoho healthy) → behavior unchanged, lead pushed immediately

https://claude.ai/code/session_01LRGyp5kD1DC5LM7EuyGqyB

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRGyp5kD1DC5LM7EuyGqyB)_